### PR TITLE
Update existing images to use webp

### DIFF
--- a/docs/front-end/sustainability.md
+++ b/docs/front-end/sustainability.md
@@ -6,4 +6,4 @@ We use lazy loading for all images below the fold.
 
 We use dark mode by default.
 
-All images should be renedered in the template file as webp format.
+All images should be renedered in the template file as webp format using the `format-webp` attribute - see https://docs.wagtail.org/en/v5.2.2/advanced_topics/images/image_file_formats.html.

--- a/tbx/project_styleguide/templates/patterns/molecules/author/author.html
+++ b/tbx/project_styleguide/templates/patterns/molecules/author/author.html
@@ -1,6 +1,6 @@
 {% load wagtailcore_tags wagtailimages_tags %}
 
-{% image author.image fill-100x100 as image %}
+{% image author.image fill-100x100 format-webp as image %}
 
 <img src="{{ image.url }}" alt="{{ image.alt }}" loading="lazy" aria-hidden="true">
 {% if author.person_page %}

--- a/tbx/project_styleguide/templates/patterns/molecules/author/author.yaml
+++ b/tbx/project_styleguide/templates/patterns/molecules/author/author.yaml
@@ -11,7 +11,7 @@ context:
 
 tags:
   image:
-    author.image fill-100x100 as image:
+    author.image fill-100x100 format-webp as image:
       target_var: image
       raw:
         alt: 'Alt'

--- a/tbx/project_styleguide/templates/patterns/molecules/blog-item/blog-item.html
+++ b/tbx/project_styleguide/templates/patterns/molecules/blog-item/blog-item.html
@@ -12,7 +12,7 @@
     {% endif %}
 
     {% if item.author %}
-        {% image item.author.image fill-100x100 %}
+        {% image item.author.image fill-100x100 format-webp %}
         {{ item.author.name }}
         {{ item.author.role }}
         {% if item.event_type %}

--- a/tbx/project_styleguide/templates/patterns/molecules/blog-item/blog-item.yaml
+++ b/tbx/project_styleguide/templates/patterns/molecules/blog-item/blog-item.yaml
@@ -7,8 +7,8 @@ context:
 
 tags:
   image:
-    item.author.image fill-100x100 class="avatar__image":
-      raw: '<img src="https://placekitten.com/100/100" class="avatar__image">'
+    item.author.image fill-100x100 format-webp:
+      raw: '<img src="https://placekitten.com/100/100">'
   pageurl:
     item:
       raw: '#'

--- a/tbx/project_styleguide/templates/patterns/molecules/blog-item/blog-item.yaml
+++ b/tbx/project_styleguide/templates/patterns/molecules/blog-item/blog-item.yaml
@@ -8,7 +8,7 @@ context:
 tags:
   image:
     item.author.image fill-100x100 format-webp:
-      raw: '<img src="https://placekitten.com/100/100">'
+      raw: '<img src="https://source.unsplash.com/100x100/?face">'
   pageurl:
     item:
       raw: '#'

--- a/tbx/project_styleguide/templates/patterns/molecules/event-item/event-item.html
+++ b/tbx/project_styleguide/templates/patterns/molecules/event-item/event-item.html
@@ -12,7 +12,7 @@
     {% endif %}
 
     {% if item.author %}
-        {% image item.author.image fill-100x100 alt="" %}
+        {% image item.author.image fill-100x100 format-webp alt="" %}
         {{ item.author.name }}
         {{ item.author.role }}
         {% if item.event_type %}

--- a/tbx/project_styleguide/templates/patterns/molecules/event-item/event-item.yaml
+++ b/tbx/project_styleguide/templates/patterns/molecules/event-item/event-item.yaml
@@ -7,7 +7,7 @@ context:
 
 tags:
   image:
-    item.author.image fill-100x100 alt="":
+    item.author.image fill-100x100 format-webp alt="":
       raw: '<img src="https://placekitten.com/100/100">'
   pageurl:
     item:

--- a/tbx/project_styleguide/templates/patterns/molecules/event-item/event-item.yaml
+++ b/tbx/project_styleguide/templates/patterns/molecules/event-item/event-item.yaml
@@ -8,7 +8,7 @@ context:
 tags:
   image:
     item.author.image fill-100x100 format-webp alt="":
-      raw: '<img src="https://placekitten.com/100/100">'
+      raw: '<img src="https://source.unsplash.com/100x100/?event">'
   pageurl:
     item:
       raw: '#'

--- a/tbx/project_styleguide/templates/patterns/molecules/related-item/related-item.html
+++ b/tbx/project_styleguide/templates/patterns/molecules/related-item/related-item.html
@@ -1,11 +1,11 @@
 {% load wagtailcore_tags wagtailimages_tags %}
 
 {% if item.image %}
-    {% image item.image width-1280 as related_item_image %}
+    {% image item.image width-1280 format-webp as related_item_image %}
 {% elif item.homepage_image %}
-    {% image item.homepage_image width-1280 as related_item_image %}
+    {% image item.homepage_image width-1280 format-webp as related_item_image %}
 {% elif item.feed_image %}
-    {% image item.feed_image width-1280 as related_item_image %}
+    {% image item.feed_image width-1280 format-webp as related_item_image %}
 {% endif %}
 
 {% if item.url %}

--- a/tbx/project_styleguide/templates/patterns/molecules/related-item/related-item.yaml
+++ b/tbx/project_styleguide/templates/patterns/molecules/related-item/related-item.yaml
@@ -4,10 +4,11 @@ context:
     subtitle: Oxfam
     description: Following the launch of a new public engagement strategy Oxfam needed a website to ‘make it happen’ by reshaping and tailoring the entire experience to the needs of Oxfam’s supporters.
     url: '#'
+    image: True
 
 tags:
   image:
-    item.image width-1280 as image:
-      target_var: image
+    item.image width-1280 format-webp as related_item_image:
+      target_var: related_item_image
       raw:
         url: '//placekitten.com/1280/800'

--- a/tbx/project_styleguide/templates/patterns/molecules/related-item/related-item.yaml
+++ b/tbx/project_styleguide/templates/patterns/molecules/related-item/related-item.yaml
@@ -8,7 +8,7 @@ context:
 
 tags:
   image:
-    item.image width-1280 format-webp as related_item_image:
+    image item.image width-1280 format-webp as related_item_image:
       target_var: related_item_image
       raw:
-        url: '//placekitten.com/1280/800'
+        url: 'https://source.unsplash.com/1280x800/?trees'

--- a/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/aligned_image_block.html
+++ b/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/aligned_image_block.html
@@ -1,8 +1,8 @@
 {% load wagtailcore_tags wagtailimages_tags %}
 {% if value.alignment == 'full' %}
-    {% image value.image max-1280x860 as aligned_image %}
+    {% image value.image max-1280x860 format-webp as aligned_image %}
 {% else %}
-    {% image value.image max-730x490 as aligned_image %}
+    {% image value.image max-730x490 format-webp as aligned_image %}
 {% endif %}
 <img src="{{ aligned_image.url }}" alt="{{ aligned_image.alt }}" height="{{ aligned_image.height }}" width="{{ aligned_image.width }}" loading="lazy" />
 {% if value.caption %}

--- a/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/aligned_image_block.yaml
+++ b/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/aligned_image_block.yaml
@@ -6,7 +6,7 @@ context:
 
 tags:
   image:
-    value.image max-1280x860 as aligned_image:
+    value.image max-1280x860 format-webp as aligned_image:
       target_var: aligned_image
       raw:
         url: '//placekitten.com/1280/860'

--- a/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/aligned_image_block.yaml
+++ b/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/aligned_image_block.yaml
@@ -9,7 +9,7 @@ tags:
     value.image max-1280x860 format-webp as aligned_image:
       target_var: aligned_image
       raw:
-        url: '//placekitten.com/1280/860'
+        url: 'https://source.unsplash.com/1280x860/?trees'
         alt: Some alt
         height: 860
         width: 1280

--- a/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/wide_image_block.html
+++ b/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/wide_image_block.html
@@ -1,6 +1,6 @@
 {% load wagtailimages_tags %}
 
 <div class="streamfield__wide-image">
-    {% image value.image max-1600x900 as wide_image %}
+    {% image value.image max-1600x900 format-webp as wide_image %}
     <img src="{{ wide_image.url }}" alt="{{ wide_image.alt }}" height="{{ wide_image.height }}" width="{{ wide_image.width }}" loading="lazy" />
 </div>

--- a/tbx/project_styleguide/templates/patterns/molecules/team-member/team-member.html
+++ b/tbx/project_styleguide/templates/patterns/molecules/team-member/team-member.html
@@ -1,6 +1,6 @@
 {% load wagtailcore_tags wagtailimages_tags %}
 
-{% image item.image fill-550x550 as image %}
+{% image item.image fill-550x550 format-webp as image %}
 <a href="{% pageurl item %}">
     <img src="{{ image.url }}" aria-hidden="true" width="{{ image.width }}" height="{{ image.height }}" loading="lazy" alt="">
     <h2>{{ item.title }}</h2>

--- a/tbx/project_styleguide/templates/patterns/molecules/team-member/team-member.yaml
+++ b/tbx/project_styleguide/templates/patterns/molecules/team-member/team-member.yaml
@@ -10,7 +10,7 @@ tags:
     item.image fill-550x550 format-webp as image:
       target_var: image
       raw:
-        url: '//placekitten.com/550/550'
+        url: 'https://source.unsplash.com/550x550/?person'
 
   pageurl:
     item:

--- a/tbx/project_styleguide/templates/patterns/molecules/team-member/team-member.yaml
+++ b/tbx/project_styleguide/templates/patterns/molecules/team-member/team-member.yaml
@@ -7,7 +7,7 @@ context:
 
 tags:
   image:
-    item.image fill-550x550 as image:
+    item.image fill-550x550 format-webp as image:
       target_var: image
       raw:
         url: '//placekitten.com/550/550'

--- a/tbx/project_styleguide/templates/patterns/organisms/footer/footer.html
+++ b/tbx/project_styleguide/templates/patterns/organisms/footer/footer.html
@@ -10,10 +10,10 @@
                             {% with link=logo.link.0.value %}
                                 {% if link %}
                                     <a href="{{ link.url }}" title="{{ link.link_text }}">
-                                        {% image logo.image height-90 loading="lazy" alt=link.link_text %}
+                                        {% image logo.image height-90 format-webp loading="lazy" alt=link.link_text %}
                                     </a>
                                 {% else %}
-                                    {% image logo.image height-90 loading="lazy" %}
+                                    {% image logo.image height-90 format-webp loading="lazy" %}
                                 {% endif %}
                             {% endwith %}
                         </li>

--- a/tbx/project_styleguide/templates/patterns/pages/team/team_detail.html
+++ b/tbx/project_styleguide/templates/patterns/pages/team/team_detail.html
@@ -4,7 +4,7 @@
 {% block content %}
     {% include "patterns/molecules/title-block/title-block.html" with item=page meta=page.role %}
 
-    {% image page.image width-1280 %}
+    {% image page.image format-webp width-1280 %}
 
     {{ page.intro|richtext }}
     {{ page.biography|richtext }}

--- a/tbx/project_styleguide/templates/patterns/pages/team/team_detail.yaml
+++ b/tbx/project_styleguide/templates/patterns/pages/team/team_detail.yaml
@@ -8,5 +8,5 @@ context:
 
 tags:
   image:
-    page.image width-1280:
+    page.image format-webp width-1280:
       raw: '<img src="https://placekitten.com/1280/1706">'

--- a/tbx/project_styleguide/templates/patterns/pages/team/team_detail.yaml
+++ b/tbx/project_styleguide/templates/patterns/pages/team/team_detail.yaml
@@ -9,4 +9,4 @@ context:
 tags:
   image:
     page.image format-webp width-1280:
-      raw: '<img src="https://placekitten.com/1280/1706">'
+      raw: '<img src="https://source.unsplash.com/1280x800/?person">'

--- a/tbx/project_styleguide/templates/patterns/pages/team/team_listing.yaml
+++ b/tbx/project_styleguide/templates/patterns/pages/team/team_listing.yaml
@@ -21,4 +21,4 @@ tags:
     item.image fill-550x550 as image:
       target_var: image
       raw:
-        url: '//placekitten.com/550/550'
+        url: 'https://source.unsplash.com/550x550/?trees'


### PR DESCRIPTION
[Link to Ticket](https://torchbox.monday.com/boards/1192293412/pulses/1357112640)

### Description of Changes Made

Updated existing image tags to use webp format. I have not updated templates such as 'bustout.html' that I know are shortly going to be removed from the codebase.

### How to Test

Note that we cannot test webp format in the pattern library, as there we must use whatever the image service we happen to make use of uses (usually placekitten in the torchbox site).

You can test this on a person page if you have the staging data and stating images in your local build. View the person page, and inspect the image format in the network tab (see screenshot).

### Screenshots


<details>
  <summary>Expand to see more</summary>

![Screenshot 2024-01-11 at 14 42 49](https://github.com/torchbox/torchbox.com/assets/771869/f8f402db-b228-4972-a944-e80b9684cbd9)
</details>

### MR Checklist

- [x] Add a description of your pull request and instructions for the reviewer to verify your work.
- [x] If your pull request is for a specific ticket, link to it in the description.
- [x] Stay on point and keep it small so the merge request can be easily reviewed.
- [x] Tests and linting passes.

#### Unit tests

- [ ] Added
- [x] Not required

#### Documentation

- [x] Updated build docs
- [ ] Updated editor guidelines (https://docs.google.com/document/d/1PAWccdQ4tfaZsrEWmpDhvP3GH5RRmBOARFVp4b-kje8/edit?usp=sharing)
- [] Not required

Note: editor guidelines already mention this.

#### Browser testing

- [x] I have tested in the following browsers and environments (edit the list as required)
  - Latest version of Chrome on mac
  - Latest version of Firefox on mac
  - Latest version of Safari on mac
  - Safari on last two versions of iOS
  - Chrome on last two versions of Android
- [ ] Not required

#### Data protection

- [ ] Not relevant
- [ ] This adds new sources of PII and documents it and modifies Birdbath processors accordingly

#### Accessibility

- [ ] Automated WCAG 2.1 tests pass
- [ ] Manual WCAG 2.1 tests completed
- [ ] I have tested in a screen reader
- [ ] I have tested in high-contrast mode
- [ ] Any animations removed for prefers-reduced-motion
- [x] Not required

#### Sustainability

- [x] Images are optimised and lazy-loading used where appropriate
- [ ] SVGs have been optimised
- [ ] Perfomance and transfer of data considered
- [ ] If JavaScript is needed alternatives have been considered
- [ ] New font variants have not been added
- [ ] Not required
