### PR TITLE
Add coverage.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,3 +192,26 @@ root@ad84f5154816:/#
   <summary>What's with the dellar name?</summary>
     These commands draw inspiration from [Stellar](https://pypi.org/project/stellar/) — a database snapshot and restore tool that is no longer maintained.
 </details>
+
+## Tests
+
+Run python unit tests in the `web` container as follows:
+
+```sh
+# Run the whole test suite once.
+djtest
+
+# Run the whole test suite, collecting test coverage information.
+djcov
+```
+
+JavaScript unit tests for this project use [Jest](https://jestjs.io/). Here are commands you can use:
+
+```sh
+# Run the whole test suite once.
+npm run test
+# Run the whole test suite, collecting test coverage information.
+npm run test:coverage
+# Start Jest in watch mode, to run tests on a subset of the files.
+npm run test:watch
+```

--- a/docker/bashrc.sh
+++ b/docker/bashrc.sh
@@ -5,6 +5,9 @@ alias dj="python manage.py"
 if [ "$BUILD_ENV" = "dev" ]; then
     alias djrun="python manage.py runserver 0.0.0.0:8000"
     alias djtest="python manage.py test --settings=tbx.settings.test"
+    alias djcov="coverage erase && \
+                coverage run --branch manage.py test --settings=tbx.settings.test && \
+                coverage report --skip-covered --skip-empty --show-missing"
 fi
 
 # nvm

--- a/poetry.lock
+++ b/poetry.lock
@@ -417,6 +417,70 @@ files = [
 ]
 
 [[package]]
+name = "coverage"
+version = "7.4.0"
+description = "Code coverage measurement for Python"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "coverage-7.4.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:36b0ea8ab20d6a7564e89cb6135920bc9188fb5f1f7152e94e8300b7b189441a"},
+    {file = "coverage-7.4.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:0676cd0ba581e514b7f726495ea75aba3eb20899d824636c6f59b0ed2f88c471"},
+    {file = "coverage-7.4.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d0ca5c71a5a1765a0f8f88022c52b6b8be740e512980362f7fdbb03725a0d6b9"},
+    {file = "coverage-7.4.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a7c97726520f784239f6c62506bc70e48d01ae71e9da128259d61ca5e9788516"},
+    {file = "coverage-7.4.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:815ac2d0f3398a14286dc2cea223a6f338109f9ecf39a71160cd1628786bc6f5"},
+    {file = "coverage-7.4.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:80b5ee39b7f0131ebec7968baa9b2309eddb35b8403d1869e08f024efd883566"},
+    {file = "coverage-7.4.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:5b2ccb7548a0b65974860a78c9ffe1173cfb5877460e5a229238d985565574ae"},
+    {file = "coverage-7.4.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:995ea5c48c4ebfd898eacb098164b3cc826ba273b3049e4a889658548e321b43"},
+    {file = "coverage-7.4.0-cp310-cp310-win32.whl", hash = "sha256:79287fd95585ed36e83182794a57a46aeae0b64ca53929d1176db56aacc83451"},
+    {file = "coverage-7.4.0-cp310-cp310-win_amd64.whl", hash = "sha256:5b14b4f8760006bfdb6e08667af7bc2d8d9bfdb648351915315ea17645347137"},
+    {file = "coverage-7.4.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:04387a4a6ecb330c1878907ce0dc04078ea72a869263e53c72a1ba5bbdf380ca"},
+    {file = "coverage-7.4.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ea81d8f9691bb53f4fb4db603203029643caffc82bf998ab5b59ca05560f4c06"},
+    {file = "coverage-7.4.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:74775198b702868ec2d058cb92720a3c5a9177296f75bd97317c787daf711505"},
+    {file = "coverage-7.4.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:76f03940f9973bfaee8cfba70ac991825611b9aac047e5c80d499a44079ec0bc"},
+    {file = "coverage-7.4.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:485e9f897cf4856a65a57c7f6ea3dc0d4e6c076c87311d4bc003f82cfe199d25"},
+    {file = "coverage-7.4.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:6ae8c9d301207e6856865867d762a4b6fd379c714fcc0607a84b92ee63feff70"},
+    {file = "coverage-7.4.0-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:bf477c355274a72435ceb140dc42de0dc1e1e0bf6e97195be30487d8eaaf1a09"},
+    {file = "coverage-7.4.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:83c2dda2666fe32332f8e87481eed056c8b4d163fe18ecc690b02802d36a4d26"},
+    {file = "coverage-7.4.0-cp311-cp311-win32.whl", hash = "sha256:697d1317e5290a313ef0d369650cfee1a114abb6021fa239ca12b4849ebbd614"},
+    {file = "coverage-7.4.0-cp311-cp311-win_amd64.whl", hash = "sha256:26776ff6c711d9d835557ee453082025d871e30b3fd6c27fcef14733f67f0590"},
+    {file = "coverage-7.4.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:13eaf476ec3e883fe3e5fe3707caeb88268a06284484a3daf8250259ef1ba143"},
+    {file = "coverage-7.4.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:846f52f46e212affb5bcf131c952fb4075b55aae6b61adc9856222df89cbe3e2"},
+    {file = "coverage-7.4.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:26f66da8695719ccf90e794ed567a1549bb2644a706b41e9f6eae6816b398c4a"},
+    {file = "coverage-7.4.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:164fdcc3246c69a6526a59b744b62e303039a81e42cfbbdc171c91a8cc2f9446"},
+    {file = "coverage-7.4.0-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:316543f71025a6565677d84bc4df2114e9b6a615aa39fb165d697dba06a54af9"},
+    {file = "coverage-7.4.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:bb1de682da0b824411e00a0d4da5a784ec6496b6850fdf8c865c1d68c0e318dd"},
+    {file = "coverage-7.4.0-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:0e8d06778e8fbffccfe96331a3946237f87b1e1d359d7fbe8b06b96c95a5407a"},
+    {file = "coverage-7.4.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:a56de34db7b7ff77056a37aedded01b2b98b508227d2d0979d373a9b5d353daa"},
+    {file = "coverage-7.4.0-cp312-cp312-win32.whl", hash = "sha256:51456e6fa099a8d9d91497202d9563a320513fcf59f33991b0661a4a6f2ad450"},
+    {file = "coverage-7.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:cd3c1e4cb2ff0083758f09be0f77402e1bdf704adb7f89108007300a6da587d0"},
+    {file = "coverage-7.4.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:e9d1bf53c4c8de58d22e0e956a79a5b37f754ed1ffdbf1a260d9dcfa2d8a325e"},
+    {file = "coverage-7.4.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:109f5985182b6b81fe33323ab4707011875198c41964f014579cf82cebf2bb85"},
+    {file = "coverage-7.4.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3cc9d4bc55de8003663ec94c2f215d12d42ceea128da8f0f4036235a119c88ac"},
+    {file = "coverage-7.4.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cc6d65b21c219ec2072c1293c505cf36e4e913a3f936d80028993dd73c7906b1"},
+    {file = "coverage-7.4.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5a10a4920def78bbfff4eff8a05c51be03e42f1c3735be42d851f199144897ba"},
+    {file = "coverage-7.4.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:b8e99f06160602bc64da35158bb76c73522a4010f0649be44a4e167ff8555952"},
+    {file = "coverage-7.4.0-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:7d360587e64d006402b7116623cebf9d48893329ef035278969fa3bbf75b697e"},
+    {file = "coverage-7.4.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:29f3abe810930311c0b5d1a7140f6395369c3db1be68345638c33eec07535105"},
+    {file = "coverage-7.4.0-cp38-cp38-win32.whl", hash = "sha256:5040148f4ec43644702e7b16ca864c5314ccb8ee0751ef617d49aa0e2d6bf4f2"},
+    {file = "coverage-7.4.0-cp38-cp38-win_amd64.whl", hash = "sha256:9864463c1c2f9cb3b5db2cf1ff475eed2f0b4285c2aaf4d357b69959941aa555"},
+    {file = "coverage-7.4.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:936d38794044b26c99d3dd004d8af0035ac535b92090f7f2bb5aa9c8e2f5cd42"},
+    {file = "coverage-7.4.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:799c8f873794a08cdf216aa5d0531c6a3747793b70c53f70e98259720a6fe2d7"},
+    {file = "coverage-7.4.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e7defbb9737274023e2d7af02cac77043c86ce88a907c58f42b580a97d5bcca9"},
+    {file = "coverage-7.4.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a1526d265743fb49363974b7aa8d5899ff64ee07df47dd8d3e37dcc0818f09ed"},
+    {file = "coverage-7.4.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bf635a52fc1ea401baf88843ae8708591aa4adff875e5c23220de43b1ccf575c"},
+    {file = "coverage-7.4.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:756ded44f47f330666843b5781be126ab57bb57c22adbb07d83f6b519783b870"},
+    {file = "coverage-7.4.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:0eb3c2f32dabe3a4aaf6441dde94f35687224dfd7eb2a7f47f3fd9428e421058"},
+    {file = "coverage-7.4.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:bfd5db349d15c08311702611f3dccbef4b4e2ec148fcc636cf8739519b4a5c0f"},
+    {file = "coverage-7.4.0-cp39-cp39-win32.whl", hash = "sha256:53d7d9158ee03956e0eadac38dfa1ec8068431ef8058fe6447043db1fb40d932"},
+    {file = "coverage-7.4.0-cp39-cp39-win_amd64.whl", hash = "sha256:cfd2a8b6b0d8e66e944d47cdec2f47c48fef2ba2f2dff5a9a75757f64172857e"},
+    {file = "coverage-7.4.0-pp38.pp39.pp310-none-any.whl", hash = "sha256:c530833afc4707fe48524a44844493f36d8727f04dcce91fb978c414a8556cc6"},
+    {file = "coverage-7.4.0.tar.gz", hash = "sha256:707c0f58cb1712b8809ece32b68996ee1e609f71bd14615bd8f87a1293cb610e"},
+]
+
+[package.extras]
+toml = ["tomli"]
+
+[[package]]
 name = "cryptography"
 version = "41.0.7"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
@@ -2721,4 +2785,4 @@ gunicorn = ["gunicorn"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "5dc8c4c3fd1a65d26f9e4f2d1419db981ac3df754a9797a0f85be1c7f6480be2"
+content-hash = "d88960d9fdd92b3568d3dccbb95b996b98e7d13a9a3812ac1e9b8ee3f9236584"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2785,4 +2785,4 @@ gunicorn = ["gunicorn"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "d88960d9fdd92b3568d3dccbb95b996b98e7d13a9a3812ac1e9b8ee3f9236584"
+content-hash = "d84c0beebb601b121c8b061e1935960c3152497cb4b183f2b0a3f28c624f56c4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ gunicorn = ["gunicorn"]
 
 [tool.poetry.dev-dependencies]
 Werkzeug = "^2.1.2"
+coverage = "^7.4.0"
 django-debug-toolbar = "^4.1.0"
 django-extensions = "^3.2.1"
 fabric = "^3.2.2"


### PR DESCRIPTION
[Link to Ticket](https://torchbox.monday.com/boards/1192293412/pulses/1364055152)

### Description of Changes Made

This adds `coverage.py` to the project, so we can check python test coverage.

In addition, a shell alias `djcov` is added, in addition to the existing `djrun` and `djtest`.

### How to Test

- `fab build`
- `fab start && fab sh`
- run `djcov` in the `web` container

### Screenshots

<details>
  <summary>Expand to see more</summary>

```console
tbx@aa7c03991478:/app$ djcov
Found 14 test(s).
Creating test database for alias 'default'...
System check identified some issues:

WARNINGS:
?: (templates.E003) 'navigation_tags' is used for multiple template tag modules: 'tbx.navigation.templatetags.navigation_tags', 'tbx.project_styleguide.templatetags.navigation_tags'
?: (templates.E003) 'wagtailcore_tags' is used for multiple template tag modules: 'tbx.project_styleguide.templatetags.wagtailcore_tags', 'wagtail.templatetags.wagtailcore_tags'
?: (templates.E003) 'wagtailimages_tags' is used for multiple template tag modules: 'tbx.project_styleguide.templatetags.wagtailimages_tags', 'wagtail.images.templatetags.wagtailimages_tags'

System check identified 3 issues (0 silenced).
..[2024-01-12 15:01:05,642][502][INFO][wagtail] Page created: "Test page" id=3 content_type=wagtailcore.Page path=/
[2024-01-12 15:01:05,664][502][INFO][wagtail] Page created: "Home" id=4 content_type=torchbox.HomePage path=/home/
.[2024-01-12 15:01:05,694][502][INFO][wagtail] Page created: "Test page" id=5 content_type=wagtailcore.Page path=/
[2024-01-12 15:01:05,728][502][INFO][wagtail] Page created: "Home" id=6 content_type=torchbox.HomePage path=/home/
.[2024-01-12 15:01:05,754][502][INFO][wagtail] Page created: "Test page" id=7 content_type=wagtailcore.Page path=/
[2024-01-12 15:01:05,787][502][INFO][wagtail] Page created: "Home" id=8 content_type=torchbox.HomePage path=/home/
.[2024-01-12 15:01:05,836][502][INFO][wagtail] Page created: "Test page" id=9 content_type=wagtailcore.Page path=/
[2024-01-12 15:01:05,868][502][INFO][wagtail] Page created: "Home" id=10 content_type=torchbox.HomePage path=/home/
.[2024-01-12 15:01:05,920][502][INFO][wagtail] Page created: "Test page" id=11 content_type=wagtailcore.Page path=/
[2024-01-12 15:01:05,960][502][INFO][wagtail] Page created: "Home" id=12 content_type=torchbox.HomePage path=/home/
.[2024-01-12 15:01:06,022][502][INFO][wagtail] Page created: "Test page" id=13 content_type=wagtailcore.Page path=/
[2024-01-12 15:01:06,038][502][INFO][wagtail] Page created: "Home" id=14 content_type=torchbox.HomePage path=/home/
.[2024-01-12 15:01:06,052][502][INFO][wagtail] Page created: "Test page" id=15 content_type=wagtailcore.Page path=/
[2024-01-12 15:01:06,067][502][INFO][wagtail] Page created: "Home" id=16 content_type=torchbox.HomePage path=/home/
......
----------------------------------------------------------------------
Ran 14 tests in 0.898s

OK
Destroying test database for alias 'default'...
Name                                             Stmts   Miss Branch BrPart  Cover   Missing
--------------------------------------------------------------------------------------------
manage.py                                            6      0      2      1    88%   5->exit
tbx/blog/feeds.py                                   31     13      6      0    49%   18, 21, 24, 27, 30, 33, 36-37, 40-42, 45-46
tbx/blog/models.py                                 130     52     38      0    58%   52-62, 67-72, 76-121, 132, 205-211, 215-218, 234-244, 248, 252-259, 264-267, 271-274, 278, 300-301
tbx/core/blocks.py                                 160     23     20      0    78%   32-35, 39-42, 169-174, 187-205
tbx/core/models.py                                 152     15     14      0    89%   54-59, 133, 203-207, 211-219, 316, 326
tbx/core/templatetags/reading_time_tags.py          31     22     10      0    27%   26-61
tbx/core/templatetags/torchbox_tags.py              89     49     48      0    53%   15, 21, 26-29, 34-37, 42-46, 51-55, 60, 65, 70, 78-79, 89-90, 100-101, 111, 120-125, 138-148, 159-187
tbx/core/templatetags/util_tags.py                  16      6      6      0    73%   12-15, 21, 26
tbx/core/utils/__init__.py                          42     37     16      0     9%   8-76, 83-92
tbx/core/utils/cache.py                             23      5      8      0    71%   10-14, 38
tbx/core/utils/views.py                              5      2      0      0    60%   5, 9
tbx/core/views.py                                   25      5      4      0    76%   14-25, 29-37
tbx/core/wagtail_hooks.py                           28     13     12      0    52%   16-31, 36, 45-50
tbx/images/models.py                                12      1      2      0    93%   13
tbx/navigation/models.py                            51      2     16      2    94%   21, 73
tbx/navigation/templatetags/navigation_tags.py      10      4      4      0    71%   11-12, 28-29
tbx/people/factories.py                             31      2     10      2    90%   64, 70
tbx/people/forms.py                                  8      4      2      0    40%   7-16
tbx/people/models.py                               108     25     28      0    73%   68-71, 86-93, 97, 116, 152-154, 157-163, 166, 184-186, 206, 236, 246-251
tbx/settings/base.py                               168     77     78     24    48%   15, 26->29, 29->39, 193, 211-241, 288, 291-294, 297, 300, 303, 306, 309, 312, 321-344, 368-371, 387-406, 441, 453-468, 479-480, 487-488, 501-502, 519, 530, 536, 539
tbx/taxonomy/factories.py                           21      2     10      2    87%   37, 48
tbx/taxonomy/models.py                              14      1      0      0    93%   19
tbx/urls.py                                         37     11      6      2    65%   33-58, 69-71
tbx/work/models.py                                 121     49     32      0    58%   97-103, 107-114, 119-122, 126-135, 139-142, 146, 188-197, 202-207, 211-256, 263, 279-280
--------------------------------------------------------------------------------------------
TOTAL                                             1636    420    380     33    70%

61 files skipped due to complete coverage.
tbx@aa7c03991478:/app$ 
```

</details>

### MR Checklist

- [x] Add a description of your pull request and instructions for the reviewer to verify your work.
- [x] If your pull request is for a specific ticket, link to it in the description.
- [x] Stay on point and keep it small so the merge request can be easily reviewed.
- [x] Tests and linting passes.

#### Unit tests

- [ ] Added
- [x] Not required

#### Documentation

- [x] Updated build docs
- [ ] Updated editor guidelines (https://docs.google.com/document/d/1PAWccdQ4tfaZsrEWmpDhvP3GH5RRmBOARFVp4b-kje8/edit?usp=sharing)
- [ ] Not required

#### Browser testing

- [ ] I have tested in the following browsers and environments (edit the list as required)
  - Latest version of Chrome on mac
  - Latest version of Firefox on mac
  - Latest version of Safari on mac
  - Safari on last two versions of iOS
  - Chrome on last two versions of Android
- [x] Not required

#### Data protection

- [ ] Not relevant
- [x] This adds new sources of PII and documents it and modifies Birdbath processors accordingly

#### Accessibility

- [ ] Automated WCAG 2.1 tests pass
- [ ] Manual WCAG 2.1 tests completed
- [ ] I have tested in a screen reader
- [ ] I have tested in high-contrast mode
- [ ] Any animations removed for prefers-reduced-motion
- [x] Not required

#### Sustainability

- [ ] Images are optimised and lazy-loading used where appropriate
- [ ] SVGs have been optimised
- [ ] Perfomance and transfer of data considered
- [ ] If JavaScript is needed alternatives have been considered
- [ ] New font variants have not been added
- [x] Not required

#### Pattern library

- [ ] The pattern library component for this template displays correctly, and does not break parent templates
- [ ] The styleguide is updated if relevant
- [x] Changes are not relevant the pattern library
