### PR TITLE
Fix a couple of points spotted when showing lauren the listing code

### DIFF
--- a/tbx/project_styleguide/templates/patterns/molecules/listing/listing--image.html
+++ b/tbx/project_styleguide/templates/patterns/molecules/listing/listing--image.html
@@ -11,7 +11,7 @@
         {# alt text is empty for consistency with listing--avatar.html where the image is inside the link, and therefore not announced #}
         <picture>
             <source media="(max-width: 598px)" srcset="{{  listing_mobile_image.url }} 1x, {{ listing_mobile_image_retina.url }} 2x" />
-            <source media="(min-width: 599px)" srcset="{{ listing_desktop_image_retina.url }} 1x, {{ listing_desktop_image_retina.url }} 2x" />
+            <source media="(min-width: 599px)" srcset="{{ listing_desktop_image.url }} 1x, {{ listing_desktop_image_retina.url }} 2x" />
             <img src="{{ listing_desktop_image.url }}" alt="" loading="lazy" class="listing-image__image" />
         </picture>
     </div>

--- a/tbx/static_src/sass/components/_listing-avatar.scss
+++ b/tbx/static_src/sass/components/_listing-avatar.scss
@@ -37,7 +37,6 @@
 
     &__tags {
         @include media-query(medium) {
-            grid-row: 2 / 3;
             margin-left: calc(#{$avatar-size-desktop} + #{$spacer-half});
         }
     }


### PR DESCRIPTION
No ticket

### Description of Changes Made

- Removes unused grid property on the avatar listing tags
- Fixes the image used for non-retina desktop for the listing image.

### How to Test

- Check that the correct image loads on a non-retina screen at desktop
- Confirm the tags layout for the image is unchanged.

### Screenshots

<details>
  <summary>Expand to see more</summary>

</details>

### MR Checklist

- [x] Add a description of your pull request and instructions for the reviewer to verify your work.
- [ ] If your pull request is for a specific ticket, link to it in the description.
- [x] Stay on point and keep it small so the merge request can be easily reviewed.
- [x] Tests and linting passes.

#### Unit tests

- [ ] Added
- [x] Not required

#### Documentation

- [ ] Updated build docs
- [ ] Updated editor guidelines (https://docs.google.com/document/d/1PAWccdQ4tfaZsrEWmpDhvP3GH5RRmBOARFVp4b-kje8/edit?usp=sharing)
- [x] Not required

#### Browser testing

- [x] I have tested in the following browsers and environments (edit the list as required)
  - Latest version of Chrome on mac
- [ ] Not required

#### Data protection

- [x] Not relevant
- [ ] This adds new sources of PII and documents it and modifies Birdbath processors accordingly

#### Accessibility

- [ ] Automated WCAG 2.1 tests pass
- [ ] Manual WCAG 2.1 tests completed
- [ ] I have tested in a screen reader
- [ ] I have tested in high-contrast mode
- [ ] Any animations removed for prefers-reduced-motion
- [x] Not required

#### Sustainability

- [ ] Images are optimised and lazy-loading used where appropriate
- [ ] SVGs have been optimised
- [ ] Perfomance and transfer of data considered
- [ ] If JavaScript is needed alternatives have been considered
- [ ] New font variants have not been added
- [x] Not required

#### Pattern library

- [ ] The pattern library component for this template displays correctly, and does not break parent templates
- [ ] The styleguide is updated if relevant
- [x] Changes are not relevant the pattern library
