### PR TITLE
Fix avatar images width

### DIFF
--- a/tbx/static_src/sass/components/_avatar.scss
+++ b/tbx/static_src/sass/components/_avatar.scss
@@ -55,6 +55,7 @@
 
     &__image {
         border-radius: 50%;
+        width: 100%;
     }
 
     // Make sure avatars don't get squashed on small screens


### PR DESCRIPTION
### Description of Changes Made

Make avatar images 100% width so they don't shrink on retina screens

### How to Test

Test on a retina screen or in dev tools with a device pixel ratio of 2. Avatar images should not be smaller than the surrounding rings.

### Screenshots

<details>
  <summary>Expand to see more</summary>

![Screenshot 2024-01-30 at 09 45 16](https://github.com/torchbox/torchbox.com/assets/31627284/b1330511-26b7-4809-a500-fa7b3d8fc09f)

</details>

### MR Checklist

- [x] Add a description of your pull request and instructions for the reviewer to verify your work.
- [ ] If your pull request is for a specific ticket, link to it in the description.
- [x] Stay on point and keep it small so the merge request can be easily reviewed.
- [ ] Tests and linting passes.

#### Unit tests

- [ ] Added
- [x] Not required

#### Documentation

- [ ] Updated build docs
- [ ] Updated editor guidelines (https://docs.google.com/document/d/1PAWccdQ4tfaZsrEWmpDhvP3GH5RRmBOARFVp4b-kje8/edit?usp=sharing)
- [x] Not required

#### Browser testing

- [x] I have tested in the following browsers and environments (edit the list as required)
  - Latest version of Chrome on mac
  - Latest version of Firefox on mac
  - Latest version of Safari on mac
  - Safari on last two versions of iOS
  - Chrome on last two versions of Android
- [ ] Not required

#### Data protection

- [x] Not relevant
- [ ] This adds new sources of PII and documents it and modifies Birdbath processors accordingly

#### Accessibility

- [ ] Automated WCAG 2.1 tests pass
- [ ] Manual WCAG 2.1 tests completed
- [ ] I have tested in a screen reader
- [ ] I have tested in high-contrast mode
- [ ] Any animations removed for prefers-reduced-motion
- [x] Not required

#### Sustainability

- [ ] Images are optimised and lazy-loading used where appropriate
- [ ] SVGs have been optimised
- [ ] Perfomance and transfer of data considered
- [ ] If JavaScript is needed alternatives have been considered
- [x] Not required

#### Pattern library

- [ ] The pattern library component for this template displays correctly, and does not break parent templates
- [ ] The styleguide is updated if relevant
- [x] Changes are not relevant the pattern library
