### PR TITLE
Historical work page -  adjust margin

### DIFF
--- a/tbx/static_src/sass/components/_grid.scss
+++ b/tbx/static_src/sass/components/_grid.scss
@@ -148,16 +148,14 @@
 
     // Move everything over by 1 column on the blog page and work pages
     .template-blog-page &,
-    .template-work-page &,
-    .template-historical-work-page & {
+    .template-work-page & {
         &__heading,
         &__intro,
         &__paragraph,
         &__image,
         &__raw-html,
         &__markdown,
-        &__embed,
-        &__stats {
+        &__embed {
             @include media-query(large) {
                 grid-column: 5 / span 7;
             }
@@ -225,6 +223,50 @@
             @include media-query(large) {
                 margin-bottom: $spacer;
                 grid-column: 1 / span 13;
+            }
+        }
+    }
+
+    .template-historical-work-page & {
+        &__heading,
+        &__intro,
+        &__paragraph,
+        &__image,
+        &__raw-html,
+        &__markdown,
+        &__embed {
+            @include media-query(large) {
+                grid-column: 2 / span 7;
+            }
+        }
+
+        &__title {
+            @include media-query(large) {
+                grid-column: 2 / span 9;
+            }
+        }
+
+        &__call-to-action {
+            @include media-query(large) {
+                grid-column: 2 / span 10;
+            }
+        }
+
+        &__quote {
+            @include media-query(large) {
+                grid-column: 2 / span 9;
+            }
+        }
+
+        &__image {
+            @include media-query(large) {
+                grid-column: 2 / span 11;
+            }
+        }
+
+        &__stats {
+            @include media-query(large) {
+                grid-column: 2 / span 9;
             }
         }
     }


### PR DESCRIPTION
[Link to Ticket](https://torchbox.monday.com/boards/1192293412/pulses/1370032957)

### Description of Changes Made

Moves the left-hand margin for the historical work pages completely to the left to align with the intro above (discussed and confirmed with Ben that this new position is correct, even though it then aligns differently with the 'More' heading below compared to other pages)

### How to Test

View any historical work page, e.g http://localhost:8000/work/google-ad-grants-mozilla/

### Screenshots

<details>
  <summary>Expand to see more</summary>

</details>

### MR Checklist

- [x] Add a description of your pull request and instructions for the reviewer to verify your work.
- [x] If your pull request is for a specific ticket, link to it in the description.
- [x] Stay on point and keep it small so the merge request can be easily reviewed.
- [x] Tests and linting passes.

#### Unit tests

- [ ] Added
- [x] Not required

#### Documentation

- [ ] Updated build docs
- [ ] Updated editor guidelines (https://docs.google.com/document/d/1PAWccdQ4tfaZsrEWmpDhvP3GH5RRmBOARFVp4b-kje8/edit?usp=sharing)
- [x] Not required

#### Browser testing

- [x] I have tested in the following browsers and environments (edit the list as required)
  - Latest version of Chrome on mac
- [ ] Not required

#### Data protection

- [x] Not relevant
- [ ] This adds new sources of PII and documents it and modifies Birdbath processors accordingly

#### Accessibility

- [ ] Automated WCAG 2.1 tests pass
- [ ] Manual WCAG 2.1 tests completed
- [ ] I have tested in a screen reader
- [ ] I have tested in high-contrast mode
- [ ] Any animations removed for prefers-reduced-motion
- [x] Not required

#### Sustainability

- [ ] Images are optimised and lazy-loading used where appropriate
- [ ] SVGs have been optimised
- [ ] Perfomance and transfer of data considered
- [ ] If JavaScript is needed alternatives have been considered
- [x] Not required

#### Pattern library

- [ ] The pattern library component for this template displays correctly, and does not break parent templates
- [ ] The styleguide is updated if relevant
- [x] Changes are not relevant the pattern library
