### PR TITLE
Even up spacing between headings and paragraphs

### DIFF
--- a/tbx/static_src/sass/components/_grid.scss
+++ b/tbx/static_src/sass/components/_grid.scss
@@ -147,6 +147,7 @@
     }
 
     // if paragraph is followed by a heading or another paragraph, reduce the bottom margin
+    // so that it matches headings and paragraphs within a rich-text block
     &__paragraph:has(+ .grid__heading),
     &__paragraph:has(+ .grid__paragraph) {
         margin-bottom: $spacer-small;

--- a/tbx/static_src/sass/components/_grid.scss
+++ b/tbx/static_src/sass/components/_grid.scss
@@ -146,6 +146,15 @@
         }
     }
 
+    // if paragraph is followed by a heading or another paragraph, reduce the bottom margin
+    &__paragraph:has(+ .grid__heading),
+    &__paragraph:has(+ .grid__paragraph) {
+        margin-bottom: $spacer-small;
+        @include media-query(large) {
+            margin-bottom: $spacer-medium;
+        }
+    }
+
     // Footer grid elements
     &__footer-line {
         grid-column: 1 / span 4;


### PR DESCRIPTION
No ticket - just a slack discussion here: https://torchbox.slack.com/archives/C05UJJT4CCE/p1707308171032959

### Description of Changes Made
The spacing between different paragraph and heading blocks was quite a bit larger than that between headings and paragraphs *within* the same paragraph block. This reduces the gap when a paragraph block is followed by a heading or another paragraph block, allowing editors to use either method without it appearing different.

### How to Test

Create a page with sets of headings and paragraphs both inside a paragraph block and separately in their own blocks. The spacing should look identical.

### Screenshots

<details>
  <summary>Expand to see more</summary>

Wagtail:
![screencapture-localhost-8000-admin-pages-2196-edit-2024-02-07-12_15_44](https://github.com/torchbox/torchbox.com/assets/771869/8c8ce3bc-b551-425f-9815-0994bdcdb92e)

Published page before:
![screencapture-localhost-8000-about-2024-02-07-12_12_49](https://github.com/torchbox/torchbox.com/assets/771869/1f825ece-f4ed-463b-bd7b-1dda9ee290b3)

Published page after:
![Screenshot 2024-02-08 at 08 18 07](https://github.com/torchbox/torchbox.com/assets/771869/1d108510-502b-45d9-9d47-a8a095e9729d)

</details>

### MR Checklist

- [x] Add a description of your pull request and instructions for the reviewer to verify your work.
- [x] If your pull request is for a specific ticket, link to it in the description.
- [x] Stay on point and keep it small so the merge request can be easily reviewed.
- [x] Tests and linting passes.

#### Unit tests

- [ ] Added
- [x] Not required

#### Documentation

- [ ] Updated build docs
- [ ] Updated editor guidelines (https://docs.google.com/document/d/1PAWccdQ4tfaZsrEWmpDhvP3GH5RRmBOARFVp4b-kje8/edit?usp=sharing)
- [x] Not required

#### Browser testing

- [x] I have tested in the following browsers and environments (edit the list as required)
  - Latest version of Chrome on mac
  - Latest version of Firefox on mac
  - Latest version of Safari on mac
  - Safari on last two versions of iOS
  - Chrome on last two versions of Android
- [ ] Not required

#### Data protection

- [x] Not relevant
- [ ] This adds new sources of PII and documents it and modifies Birdbath processors accordingly

#### Accessibility

- [ ] Automated WCAG 2.1 tests pass
- [ ] Manual WCAG 2.1 tests completed
- [ ] I have tested in a screen reader
- [ ] I have tested in high-contrast mode
- [ ] Any animations removed for prefers-reduced-motion
- [x] Not required

#### Sustainability

- [ ] Images are optimised and lazy-loading used where appropriate
- [ ] SVGs have been optimised
- [ ] Perfomance and transfer of data considered
- [ ] If JavaScript is needed alternatives have been considered
- [x] Not required

#### Pattern library

- [ ] The pattern library component for this template displays correctly, and does not break parent templates
- [ ] The styleguide is updated if relevant
- [x] Changes are not relevant the pattern library
