### PR TITLE
Ensure the team page images are lazy-loaded

### DIFF
--- a/tbx/project_styleguide/templates/patterns/pages/team/team_listing.html
+++ b/tbx/project_styleguide/templates/patterns/pages/team/team_listing.html
@@ -8,7 +8,12 @@
         <ul class="team-listing grid__team-listing">
             {% for member in people %}
                 <li class="team-listing__item">
-                    {% srcset_image member.image format-webp fill-{230x230,370x370} sizes="(max-width: 598px) 370px, (min-width: 599px) 230px" class="team-listing__image" alt="" %}
+                    {# lazy load after the first five #}
+                    {% if forloop.counter > 5 %}
+                        {% srcset_image member.image format-webp fill-{230x230,370x370} sizes="(max-width: 598px) 370px, (min-width: 599px) 230px" class="team-listing__image" alt="" loading="lazy" %}
+                    {% else %}
+                        {% srcset_image member.image format-webp fill-{230x230,370x370} sizes="(max-width: 598px) 370px, (min-width: 599px) 230px" class="team-listing__image" alt="" %}
+                    {% endif %}
                     <a class="team-listing__link" href="{{ member.url }}">
                         {{ member.title }}
                     </a>

--- a/tbx/project_styleguide/templates/patterns/pages/team/team_listing.yaml
+++ b/tbx/project_styleguide/templates/patterns/pages/team/team_listing.yaml
@@ -31,7 +31,12 @@ context:
 tags:
   srcset_image:
     'member.image format-webp fill-{230x230,370x370} sizes="(max-width: 598px) 370px, (min-width: 599px) 230px" class="team-listing__image" alt=""':
-      raw: '<img alt="Abigail" class="team-listing__image" height="230" sizes="(max-width: 598px) 370px, (min-width: 599px) 230px" src="https://source.unsplash.com/230x230/?person" srcset="https://source.unsplash.com/230x230/?person 230w, https://source.unsplash.com/370x370/?person 370w" width="230">'
+      raw: |
+        <img alt="Abigail" class="team-listing__image" height="230" sizes="(max-width: 598px) 370px, (min-width: 599px) 230px" src="https://source.unsplash.com/230x230/?person" srcset="https://source.unsplash.com/230x230/?person 230w, https://source.unsplash.com/370x370/?person 370w" width="230">
+    'member.image format-webp fill-{230x230,370x370} sizes="(max-width: 598px) 370px, (min-width: 599px) 230px" class="team-listing__image" alt="" loading="lazy"':
+      raw: |
+        <img alt="Abigail" class="team-listing__image" height="230" sizes="(max-width: 598px) 370px, (min-width: 599px) 230px" src="https://source.unsplash.com/230x230/?person" srcset="https://source.unsplash.com/230x230/?person 230w, https://source.unsplash.com/370x370/?person 370w" width="230" loading="lazy">
+
   footerlinks:
     '':
       template_name: 'patterns/navigation/components/footer-links.html'


### PR DESCRIPTION
No ticket

### Description of Changes Made

We have been discussing issues with generating the renditions for this listing, but in the course of that I realised I had also forgotten to lazy-load the images here. The first five images are loaded initially so that all the lazy-loaded images are below the scroll at desktop.

### How to Test

Visit http://localhost:8000/team/ with the network tab open in dev tools - ensure you see the images loading as you scroll down.

### Screenshots

<details>
  <summary>Expand to see more</summary>

</details>

### MR Checklist

- [ ] Add a description of your pull request and instructions for the reviewer to verify your work.
- [ ] If your pull request is for a specific ticket, link to it in the description.
- [ ] Stay on point and keep it small so the merge request can be easily reviewed.
- [ ] Tests and linting passes.

#### Unit tests

- [ ] Added
- [ ] Not required

#### Documentation

- [ ] Updated build docs
- [ ] Updated editor guidelines (https://docs.google.com/document/d/1PAWccdQ4tfaZsrEWmpDhvP3GH5RRmBOARFVp4b-kje8/edit?usp=sharing)
- [ ] Not required

#### Browser testing

- [ ] I have tested in the following browsers and environments (edit the list as required)
  - Latest version of Chrome on mac
  - Latest version of Firefox on mac
  - Latest version of Safari on mac
  - Safari on last two versions of iOS
  - Chrome on last two versions of Android
- [ ] Not required

#### Data protection

- [ ] Not relevant
- [ ] This adds new sources of PII and documents it and modifies Birdbath processors accordingly

#### Accessibility

- [ ] Automated WCAG 2.1 tests pass
- [ ] Manual WCAG 2.1 tests completed
- [ ] I have tested in a screen reader
- [ ] I have tested in high-contrast mode
- [ ] Any animations removed for prefers-reduced-motion
- [ ] Not required

#### Sustainability

- [ ] Images are optimised and lazy-loading used where appropriate
- [ ] SVGs have been optimised
- [ ] Perfomance and transfer of data considered
- [ ] If JavaScript is needed alternatives have been considered
- [ ] Not required

#### Pattern library

- [ ] The pattern library component for this template displays correctly, and does not break parent templates
- [ ] The styleguide is updated if relevant
- [ ] Changes are not relevant the pattern library
