### PR TITLE
Image desaturation

### DIFF
--- a/docs/front-end/sustainability.md
+++ b/docs/front-end/sustainability.md
@@ -7,3 +7,5 @@ We use lazy loading for all images below the fold.
 We use dark mode by default.
 
 All images should be renedered in the template file as webp format using the `format-webp` attribute - see https://docs.wagtail.org/en/v5.2.2/advanced_topics/images/image_file_formats.html.
+
+We have a custom saturation filter that allows us to apply a slight desaturation to all images using `saturation-0.6` - this makes the file size of images smaller overall, as well as creating a cohesive look for photographic images.

--- a/tbx/core/wagtail_hooks.py
+++ b/tbx/core/wagtail_hooks.py
@@ -5,7 +5,6 @@ from django.utils.cache import add_never_cache_headers
 from django.utils.safestring import mark_safe
 
 from PIL import ImageEnhance
-
 from storages.backends.s3boto3 import S3Boto3Storage
 from wagtail import hooks
 from wagtail.documents import get_document_model

--- a/tbx/core/wagtail_hooks.py
+++ b/tbx/core/wagtail_hooks.py
@@ -4,10 +4,13 @@ from django.shortcuts import redirect
 from django.utils.cache import add_never_cache_headers
 from django.utils.safestring import mark_safe
 
+from PIL import ImageEnhance
+
 from storages.backends.s3boto3 import S3Boto3Storage
 from wagtail import hooks
 from wagtail.documents import get_document_model
 from wagtail.documents.models import document_served
+from wagtail.images.image_operations import FilterOperation
 
 
 @hooks.register("before_serve_document", order=100)
@@ -61,3 +64,20 @@ def hotjar_admin_tracking():
     </script>
     """
     )
+
+
+class ReduceSaturationOperation(FilterOperation):
+    def construct(self, factor):
+        self.factor = float(factor)
+
+    def run(self, willow, image, env):
+        enhancer = ImageEnhance.Color(willow.image)
+        willow.image = enhancer.enhance(self.factor)
+        return willow
+
+
+@hooks.register("register_image_operations")
+def register_image_operations():
+    return [
+        ("saturation", ReduceSaturationOperation),
+    ]

--- a/tbx/project_styleguide/templates/patterns/_pattern_library_only/streamfield/service_story_container.yaml
+++ b/tbx/project_styleguide/templates/patterns/_pattern_library_only/streamfield/service_story_container.yaml
@@ -12,17 +12,17 @@ tags:
       raw: |
         <img src="https://source.unsplash.com/110x70?logo" width="110" height="70" alt="Some alt" class="featured-case-study__company-logo">
     # avatar image for blog chooser
-    avatar fill-144x144 format-webp as avatar_desktop:
+    avatar fill-144x144 format-webp saturation-0.6 as avatar_desktop:
       target_var: avatar_desktop
       raw:
         alt: 'desktop image'
         url: 'https://source.unsplash.com/144x144?face'
-    avatar fill-286x286 format-webp as avatar_desktop_retina:
+    avatar fill-286x286 format-webp saturation-0.6 as avatar_desktop_retina:
       target_var: avatar_desktop_retina
       raw:
         alt: 'desktop image retina'
         url: 'https://source.unsplash.com/286x286?face'
-    avatar fill-72x72 format-webp as avatar_mobile:
+    avatar fill-72x72 format-webp saturation-0.6 as avatar_mobile:
       target_var: avatar_mobile
       raw:
         alt: 'mobile image'

--- a/tbx/project_styleguide/templates/patterns/_pattern_library_only/streamfield/service_story_container.yaml
+++ b/tbx/project_styleguide/templates/patterns/_pattern_library_only/streamfield/service_story_container.yaml
@@ -1,10 +1,10 @@
 tags:
   srcset_image:
     # Image block
-    'value.image format-webp fill-{400x225,800x450,1600x900,1280x720} sizes="(max-width: 1022px) 90vw, (max-width: 1879px) 70vw, (min-width: 1880px) 1170px" loading="lazy" alt=value.alt_text':
+    'value.image format-webp saturation-0.6 fill-{400x225,800x450,1600x900,1280x720} sizes="(max-width: 1022px) 90vw, (max-width: 1879px) 70vw, (min-width: 1880px) 1170px" loading="lazy" alt=value.alt_text':
       raw: '<img alt="Screenshot of workshop to establish tone" height="225" sizes="(max-width: 1022px) 90vw, (max-width: 1879px) 70vw, (min-width: 1880px) 1170px" src="https://source.unsplash.com/400x225?trees" srcset="https://source.unsplash.com/400x225?trees 400w, https://source.unsplash.com/800x450?trees 800w, https://source.unsplash.com/1600x900?trees 1153w, https://source.unsplash.com/1280x720?trees 1153w" width="400">'
     # Featured case study
-    'value.featured_case_study_image format-webp fill-{400x225,800x450,1600x900,1280x720} sizes="(max-width: 1022px) 90vw, (max-width: 1789px) 50vw, (min-width: 1800px) 1120px" class="featured-case-study__image"':
+    'value.featured_case_study_image format-webp saturation-0.6 fill-{400x225,800x450,1600x900,1280x720} sizes="(max-width: 1022px) 90vw, (max-width: 1789px) 50vw, (min-width: 1800px) 1120px" class="featured-case-study__image"':
       raw: '<img alt="Jeth-JulyImage_from_iOS" class="featured-case-study__image" height="225" sizes="(max-width: 1022px) 90vw, (max-width: 1789px) 50vw, (min-width: 1800px) 1120px" src="https://source.unsplash.com/400x225?tech" srcset="https://source.unsplash.com/400x225?tech 400w, https://source.unsplash.com/800x450?tech 800w, https://source.unsplash.com/1600x900?tech 1280w, https://source.unsplash.com/1280x720?tech 1280w" width="400">'
   image:
     # Featured case study logo
@@ -28,22 +28,22 @@ tags:
         alt: 'mobile image'
         url: 'https://source.unsplash.com/72x72?face'
     # listing image for work chooser
-    listing_image fill-370x370 format-webp as listing_desktop_image:
+    listing_image fill-370x370 format-webp saturation-0.6 as listing_desktop_image:
       target_var: listing_desktop_image
       raw:
         alt: 'desktop image'
         url: 'https://source.unsplash.com/370x370?trees'
-    listing_image fill-740x740 format-webp as listing_desktop_image_retina:
+    listing_image fill-740x740 format-webp saturation-0.6 as listing_desktop_image_retina:
       target_var: listing_desktop_image_retina
       raw:
         alt: 'desktop image retina'
         url: 'https://source.unsplash.com/740x740?trees'
-    listing_image fill-370x335 format-webp as listing_mobile_image:
+    listing_image fill-370x335 format-webp saturation-0.6 as listing_mobile_image:
       target_var: listing_mobile_image
       raw:
         alt: 'mobile image'
         url: 'https://source.unsplash.com/370x335?trees'
-    listing_image fill-740x670 format-webp as listing_mobile_image_retina:
+    listing_image fill-740x670 format-webp saturation-0.6 as listing_mobile_image_retina:
       target_var: listing_mobile_image_retina
       raw:
         alt: 'mobile image retina'

--- a/tbx/project_styleguide/templates/patterns/_pattern_library_only/streamfield/story_container.yaml
+++ b/tbx/project_styleguide/templates/patterns/_pattern_library_only/streamfield/story_container.yaml
@@ -1,5 +1,5 @@
 tags:
   # Image block
   srcset_image:
-    'value.image format-webp fill-{400x225,800x450,1600x900,1280x720} sizes="(max-width: 1022px) 90vw, (max-width: 1879px) 70vw, (min-width: 1880px) 1170px" loading="lazy" alt=value.alt_text':
+    'value.image format-webp saturation-0.6 fill-{400x225,800x450,1600x900,1280x720} sizes="(max-width: 1022px) 90vw, (max-width: 1879px) 70vw, (min-width: 1880px) 1170px" loading="lazy" alt=value.alt_text':
       raw: '<img alt="Screenshot of workshop to establish tone" height="225" sizes="(max-width: 1022px) 90vw, (max-width: 1879px) 70vw, (min-width: 1880px) 1170px" src="https://source.unsplash.com/400x225?trees" srcset="https://source.unsplash.com/400x225?trees 400w, https://source.unsplash.com/800x450?trees 800w, https://source.unsplash.com/1600x900?trees 1153w, https://source.unsplash.com/1280x720?trees 1153w" width="400">'

--- a/tbx/project_styleguide/templates/patterns/_pattern_library_only/streamfield/work_story_container.yaml
+++ b/tbx/project_styleguide/templates/patterns/_pattern_library_only/streamfield/work_story_container.yaml
@@ -1,5 +1,5 @@
 tags:
   # Image block
   srcset_image:
-    'value.image format-webp fill-{400x225,800x450,1600x900,1280x720} sizes="(max-width: 1022px) 90vw, (max-width: 1879px) 70vw, (min-width: 1880px) 1170px" loading="lazy" alt=value.alt_text':
+    'value.image format-webp saturation-0.6 fill-{400x225,800x450,1600x900,1280x720} sizes="(max-width: 1022px) 90vw, (max-width: 1879px) 70vw, (min-width: 1880px) 1170px" loading="lazy" alt=value.alt_text':
       raw: '<img alt="Screenshot of workshop to establish tone" height="225" sizes="(max-width: 1022px) 90vw, (max-width: 1879px) 70vw, (min-width: 1880px) 1170px" src="https://source.unsplash.com/400x225?trees" srcset="https://source.unsplash.com/400x225?trees 400w, https://source.unsplash.com/800x450?trees 800w, https://source.unsplash.com/1600x900?trees 1153w, https://source.unsplash.com/1280x720?trees 1153w" width="400">'

--- a/tbx/project_styleguide/templates/patterns/atoms/avatar/avatar.html
+++ b/tbx/project_styleguide/templates/patterns/atoms/avatar/avatar.html
@@ -4,9 +4,9 @@
 {% image avatar fill-72x72 format-webp saturation-0.6 as avatar_mobile %}
 
 <div class="avatar{% if classes %} {{ classes }}{% endif %}">
-    <picture>
-        <source media="(max-width: 598px)" srcset="{{  avatar_mobile.url }} 1x, {{ avatar_desktop.url }} 2x" />
-        <source media="(min-width: 599px)" srcset="{{ avatar_desktop.url }} 1x, {{ avatar_desktop_retina.url }} 2x" />
-        <img src="{{ avatar_desktop.url }}" alt="" {% if lazy_load %}loading="lazy"{% endif %} class="avatar__image" />
-    </picture>
+    {% if lazy_load %}
+        {% srcset_image avatar format-webp saturation-0.6 fill-{72x72,144x144,286x286} sizes="(max-width: 598px) 72px, (min-width: 599px) 145px" alt="" loading="lazy" class="avatar__image" %}
+    {% else %}
+        {% srcset_image avatar format-webp saturation-0.6 fill-{72x72,144x144,286x286} sizes="(max-width: 598px) 72px, (min-width: 599px) 145px" alt="" class="avatar__image" %}
+    {% endif %}
 </div>

--- a/tbx/project_styleguide/templates/patterns/atoms/avatar/avatar.html
+++ b/tbx/project_styleguide/templates/patterns/atoms/avatar/avatar.html
@@ -1,7 +1,7 @@
 {% load wagtailimages_tags %}
-{% image avatar fill-144x144 format-webp as avatar_desktop %}
-{% image avatar fill-286x286 format-webp as avatar_desktop_retina %}
-{% image avatar fill-72x72 format-webp as avatar_mobile %}
+{% image avatar fill-144x144 format-webp saturation-0.6 as avatar_desktop %}
+{% image avatar fill-286x286 format-webp saturation-0.6 as avatar_desktop_retina %}
+{% image avatar fill-72x72 format-webp saturation-0.6 as avatar_mobile %}
 
 <div class="avatar{% if classes %} {{ classes }}{% endif %}">
     <picture>

--- a/tbx/project_styleguide/templates/patterns/atoms/avatar/avatar.yaml
+++ b/tbx/project_styleguide/templates/patterns/atoms/avatar/avatar.yaml
@@ -1,14 +1,14 @@
 tags:
   image:
-    avatar fill-144x144 format-webp as avatar_desktop:
+    avatar fill-144x144 format-webp saturation-0.6 as avatar_desktop:
       target_var: avatar_desktop
       raw:
         url: 'https://source.unsplash.com/144x144?face'
-    avatar fill-286x286 format-webp as avatar_desktop_retina:
+    avatar fill-286x286 format-webp saturation-0.6 as avatar_desktop_retina:
       target_var: avatar_desktop_retina
       raw:
         url: 'https://source.unsplash.com/286x286?face'
-    avatar fill-72x72 format-webp as avatar_mobile:
+    avatar fill-72x72 format-webp saturation-0.6 as avatar_mobile:
       target_var: avatar_mobile
       raw:
         url: 'https://source.unsplash.com/72x72?face'

--- a/tbx/project_styleguide/templates/patterns/atoms/avatar/avatar.yaml
+++ b/tbx/project_styleguide/templates/patterns/atoms/avatar/avatar.yaml
@@ -1,14 +1,8 @@
 tags:
-  image:
-    avatar fill-144x144 format-webp saturation-0.6 as avatar_desktop:
-      target_var: avatar_desktop
-      raw:
-        url: 'https://source.unsplash.com/144x144?face'
-    avatar fill-286x286 format-webp saturation-0.6 as avatar_desktop_retina:
-      target_var: avatar_desktop_retina
-      raw:
-        url: 'https://source.unsplash.com/286x286?face'
-    avatar fill-72x72 format-webp saturation-0.6 as avatar_mobile:
-      target_var: avatar_mobile
-      raw:
-        url: 'https://source.unsplash.com/72x72?face'
+  srcset_image:
+    'avatar format-webp saturation-0.6 fill-{72x72,144x144,286x286} sizes="(max-width: 598px) 72px, (min-width: 599px) 145px" alt="" loading="lazy" class="avatar__image"':
+      raw: |
+        <img alt="" class="avatar__image" height="72" loading="lazy" sizes="(max-width: 598px) 72px, (min-width: 599px) 145px" src="https://source.unsplash.com/72x72?face" srcset="https://source.unsplash.com/72x72?face 72w, https://source.unsplash.com/144x144?face 144w, https://source.unsplash.com/286x286?face 286w" width="72">
+    'avatar format-webp saturation-0.6 fill-{72x72,144x144,286x286} sizes="(max-width: 598px) 72px, (min-width: 599px) 145px" alt="" class="avatar__image"':
+      raw: |
+        <img alt="" class="avatar__image" height="72" sizes="(max-width: 598px) 72px, (min-width: 599px) 145px" src="https://source.unsplash.com/72x72?face" srcset="https://source.unsplash.com/72x72?face 72w, https://source.unsplash.com/144x144?face 144w, https://source.unsplash.com/286x286?face 286w" width="72">

--- a/tbx/project_styleguide/templates/patterns/molecules/author/author.yaml
+++ b/tbx/project_styleguide/templates/patterns/molecules/author/author.yaml
@@ -5,19 +5,13 @@ context:
     person_page: '#'
 
 tags:
-  image:
-    avatar fill-144x144 format-webp saturation-0.6 as avatar_desktop:
-      target_var: avatar_desktop
-      raw:
-        url: 'https://source.unsplash.com/144x144?face'
-    avatar fill-286x286 format-webp saturation-0.6 as avatar_desktop_retina:
-      target_var: avatar_desktop_retina
-      raw:
-        url: 'https://source.unsplash.com/286x286?face'
-    avatar fill-72x72 format-webp saturation-0.6 as avatar_mobile:
-      target_var: avatar_mobile
-      raw:
-        url: 'https://source.unsplash.com/72x72?face'
+  srcset_image:
+    'avatar format-webp saturation-0.6 fill-{72x72,144x144,286x286} sizes="(max-width: 598px) 72px, (min-width: 599px) 145px" alt="" loading="lazy" class="avatar__image"':
+      raw: |
+        <img alt="" class="avatar__image" height="72" loading="lazy" sizes="(max-width: 598px) 72px, (min-width: 599px) 145px" src="https://source.unsplash.com/72x72?face" srcset="https://source.unsplash.com/72x72?face 72w, https://source.unsplash.com/144x144?face 144w, https://source.unsplash.com/286x286?face 286w" width="72">
+    'avatar format-webp saturation-0.6 fill-{72x72,144x144,286x286} sizes="(max-width: 598px) 72px, (min-width: 599px) 145px" alt="" class="avatar__image"':
+      raw: |
+        <img alt="" class="avatar__image" height="72" sizes="(max-width: 598px) 72px, (min-width: 599px) 145px" src="https://source.unsplash.com/72x72?face" srcset="https://source.unsplash.com/72x72?face 72w, https://source.unsplash.com/144x144?face 144w, https://source.unsplash.com/286x286?face 286w" width="72">
   pageurl:
     author.person_page:
       raw: '#'

--- a/tbx/project_styleguide/templates/patterns/molecules/author/author.yaml
+++ b/tbx/project_styleguide/templates/patterns/molecules/author/author.yaml
@@ -6,15 +6,15 @@ context:
 
 tags:
   image:
-    avatar fill-144x144 format-webp as avatar_desktop:
+    avatar fill-144x144 format-webp saturation-0.6 as avatar_desktop:
       target_var: avatar_desktop
       raw:
         url: 'https://source.unsplash.com/144x144?face'
-    avatar fill-286x286 format-webp as avatar_desktop_retina:
+    avatar fill-286x286 format-webp saturation-0.6 as avatar_desktop_retina:
       target_var: avatar_desktop_retina
       raw:
         url: 'https://source.unsplash.com/286x286?face'
-    avatar fill-72x72 format-webp as avatar_mobile:
+    avatar fill-72x72 format-webp saturation-0.6 as avatar_mobile:
       target_var: avatar_mobile
       raw:
         url: 'https://source.unsplash.com/72x72?face'

--- a/tbx/project_styleguide/templates/patterns/molecules/blog-item/blog-item.yaml
+++ b/tbx/project_styleguide/templates/patterns/molecules/blog-item/blog-item.yaml
@@ -13,19 +13,13 @@ context:
         slug: wagtail
 
 tags:
-  image:
-    avatar fill-144x144 format-webp saturation-0.6 as avatar_desktop:
-      target_var: avatar_desktop
-      raw:
-        url: 'https://source.unsplash.com/144x144?face'
-    avatar fill-286x286 format-webp saturation-0.6 as avatar_desktop_retina:
-      target_var: avatar_desktop_retina
-      raw:
-        url: 'https://source.unsplash.com/286x286?face'
-    avatar fill-72x72 format-webp saturation-0.6 as avatar_mobile:
-      target_var: avatar_mobile
-      raw:
-        url: 'https://source.unsplash.com/72x72?face'
+  srcset_image:
+    'avatar format-webp saturation-0.6 fill-{72x72,144x144,286x286} sizes="(max-width: 598px) 72px, (min-width: 599px) 145px" alt="" loading="lazy" class="avatar__image"':
+      raw: |
+        <img alt="" class="avatar__image" height="72" loading="lazy" sizes="(max-width: 598px) 72px, (min-width: 599px) 145px" src="https://source.unsplash.com/72x72?face" srcset="https://source.unsplash.com/72x72?face 72w, https://source.unsplash.com/144x144?face 144w, https://source.unsplash.com/286x286?face 286w" width="72">
+    'avatar format-webp saturation-0.6 fill-{72x72,144x144,286x286} sizes="(max-width: 598px) 72px, (min-width: 599px) 145px" alt="" class="avatar__image"':
+      raw: |
+        <img alt="" class="avatar__image" height="72" sizes="(max-width: 598px) 72px, (min-width: 599px) 145px" src="https://source.unsplash.com/72x72?face" srcset="https://source.unsplash.com/72x72?face 72w, https://source.unsplash.com/144x144?face 144w, https://source.unsplash.com/286x286?face 286w" width="72">
   pageurl:
     item:
       raw: '#'

--- a/tbx/project_styleguide/templates/patterns/molecules/blog-item/blog-item.yaml
+++ b/tbx/project_styleguide/templates/patterns/molecules/blog-item/blog-item.yaml
@@ -14,15 +14,15 @@ context:
 
 tags:
   image:
-    avatar fill-144x144 format-webp as avatar_desktop:
+    avatar fill-144x144 format-webp saturation-0.6 as avatar_desktop:
       target_var: avatar_desktop
       raw:
         url: 'https://source.unsplash.com/144x144?face'
-    avatar fill-286x286 format-webp as avatar_desktop_retina:
+    avatar fill-286x286 format-webp saturation-0.6 as avatar_desktop_retina:
       target_var: avatar_desktop_retina
       raw:
         url: 'https://source.unsplash.com/286x286?face'
-    avatar fill-72x72 format-webp as avatar_mobile:
+    avatar fill-72x72 format-webp saturation-0.6 as avatar_mobile:
       target_var: avatar_mobile
       raw:
         url: 'https://source.unsplash.com/72x72?face'

--- a/tbx/project_styleguide/templates/patterns/molecules/footer-cta/footer-cta.yaml
+++ b/tbx/project_styleguide/templates/patterns/molecules/footer-cta/footer-cta.yaml
@@ -7,16 +7,10 @@ context:
   contact_action: Get in touch
 
 tags:
-  image:
-    avatar fill-144x144 format-webp saturation-0.6 as avatar_desktop:
-      target_var: avatar_desktop
-      raw:
-        url: 'https://source.unsplash.com/144x144?face'
-    avatar fill-286x286 format-webp saturation-0.6 as avatar_desktop_retina:
-      target_var: avatar_desktop_retina
-      raw:
-        url: 'https://source.unsplash.com/286x286?face'
-    avatar fill-72x72 format-webp saturation-0.6 as avatar_mobile:
-      target_var: avatar_mobile
-      raw:
-        url: 'https://source.unsplash.com/72x72?face'
+  srcset_image:
+    'avatar format-webp saturation-0.6 fill-{72x72,144x144,286x286} sizes="(max-width: 598px) 72px, (min-width: 599px) 145px" alt="" loading="lazy" class="avatar__image"':
+      raw: |
+        <img alt="" class="avatar__image" height="72" loading="lazy" sizes="(max-width: 598px) 72px, (min-width: 599px) 145px" src="https://source.unsplash.com/72x72?face" srcset="https://source.unsplash.com/72x72?face 72w, https://source.unsplash.com/144x144?face 144w, https://source.unsplash.com/286x286?face 286w" width="72">
+    'avatar format-webp saturation-0.6 fill-{72x72,144x144,286x286} sizes="(max-width: 598px) 72px, (min-width: 599px) 145px" alt="" class="avatar__image"':
+      raw: |
+        <img alt="" class="avatar__image" height="72" sizes="(max-width: 598px) 72px, (min-width: 599px) 145px" src="https://source.unsplash.com/72x72?face" srcset="https://source.unsplash.com/72x72?face 72w, https://source.unsplash.com/144x144?face 144w, https://source.unsplash.com/286x286?face 286w" width="72">

--- a/tbx/project_styleguide/templates/patterns/molecules/footer-cta/footer-cta.yaml
+++ b/tbx/project_styleguide/templates/patterns/molecules/footer-cta/footer-cta.yaml
@@ -8,15 +8,15 @@ context:
 
 tags:
   image:
-    avatar fill-144x144 format-webp as avatar_desktop:
+    avatar fill-144x144 format-webp saturation-0.6 as avatar_desktop:
       target_var: avatar_desktop
       raw:
         url: 'https://source.unsplash.com/144x144?face'
-    avatar fill-286x286 format-webp as avatar_desktop_retina:
+    avatar fill-286x286 format-webp saturation-0.6 as avatar_desktop_retina:
       target_var: avatar_desktop_retina
       raw:
         url: 'https://source.unsplash.com/286x286?face'
-    avatar fill-72x72 format-webp as avatar_mobile:
+    avatar fill-72x72 format-webp saturation-0.6 as avatar_mobile:
       target_var: avatar_mobile
       raw:
         url: 'https://source.unsplash.com/72x72?face'

--- a/tbx/project_styleguide/templates/patterns/molecules/listing/listing--avatar.yaml
+++ b/tbx/project_styleguide/templates/patterns/molecules/listing/listing--avatar.yaml
@@ -14,15 +14,15 @@ context:
 
 tags:
   image:
-    avatar fill-144x144 format-webp as avatar_desktop:
+    avatar fill-144x144 format-webp saturation-0.6 as avatar_desktop:
       target_var: avatar_desktop
       raw:
         url: 'https://source.unsplash.com/144x144?face'
-    avatar fill-286x286 format-webp as avatar_desktop_retina:
+    avatar fill-286x286 format-webp saturation-0.6 as avatar_desktop_retina:
       target_var: avatar_desktop_retina
       raw:
         url: 'https://source.unsplash.com/286x286?face'
-    avatar fill-72x72 format-webp as avatar_mobile:
+    avatar fill-72x72 format-webp saturation-0.6 as avatar_mobile:
       target_var: avatar_mobile
       raw:
         url: 'https://source.unsplash.com/72x72?face'

--- a/tbx/project_styleguide/templates/patterns/molecules/listing/listing--avatar.yaml
+++ b/tbx/project_styleguide/templates/patterns/molecules/listing/listing--avatar.yaml
@@ -13,16 +13,10 @@ context:
       slug: culture
 
 tags:
-  image:
-    avatar fill-144x144 format-webp saturation-0.6 as avatar_desktop:
-      target_var: avatar_desktop
-      raw:
-        url: 'https://source.unsplash.com/144x144?face'
-    avatar fill-286x286 format-webp saturation-0.6 as avatar_desktop_retina:
-      target_var: avatar_desktop_retina
-      raw:
-        url: 'https://source.unsplash.com/286x286?face'
-    avatar fill-72x72 format-webp saturation-0.6 as avatar_mobile:
-      target_var: avatar_mobile
-      raw:
-        url: 'https://source.unsplash.com/72x72?face'
+  srcset_image:
+    'avatar format-webp saturation-0.6 fill-{72x72,144x144,286x286} sizes="(max-width: 598px) 72px, (min-width: 599px) 145px" alt="" loading="lazy" class="avatar__image"':
+      raw: |
+        <img alt="" class="avatar__image" height="72" loading="lazy" sizes="(max-width: 598px) 72px, (min-width: 599px) 145px" src="https://source.unsplash.com/72x72?face" srcset="https://source.unsplash.com/72x72?face 72w, https://source.unsplash.com/144x144?face 144w, https://source.unsplash.com/286x286?face 286w" width="72">
+    'avatar format-webp saturation-0.6 fill-{72x72,144x144,286x286} sizes="(max-width: 598px) 72px, (min-width: 599px) 145px" alt="" class="avatar__image"':
+      raw: |
+        <img alt="" class="avatar__image" height="72" sizes="(max-width: 598px) 72px, (min-width: 599px) 145px" src="https://source.unsplash.com/72x72?face" srcset="https://source.unsplash.com/72x72?face 72w, https://source.unsplash.com/144x144?face 144w, https://source.unsplash.com/286x286?face 286w" width="72">

--- a/tbx/project_styleguide/templates/patterns/molecules/listing/listing--image.html
+++ b/tbx/project_styleguide/templates/patterns/molecules/listing/listing--image.html
@@ -1,10 +1,10 @@
 {# Designed to be included from another template and values passed in #}
 {% load wagtailimages_tags %}
 
-{% image listing_image fill-370x370 format-webp as listing_desktop_image %}
-{% image listing_image fill-740x740 format-webp as listing_desktop_image_retina %}
-{% image listing_image fill-370x335 format-webp as listing_mobile_image %}
-{% image listing_image fill-740x670 format-webp as listing_mobile_image_retina %}
+{% image listing_image fill-370x370 format-webp saturation-0.6 as listing_desktop_image %}
+{% image listing_image fill-740x740 format-webp saturation-0.6 as listing_desktop_image_retina %}
+{% image listing_image fill-370x335 format-webp saturation-0.6 as listing_mobile_image %}
+{% image listing_image fill-740x670 format-webp saturation-0.6 as listing_mobile_image_retina %}
 
 <li class="listing-image listing {{ base_class }}">
     {# alt text is empty for consistency with listing--avatar.html that includes avatar.html which has empty alt text #}

--- a/tbx/project_styleguide/templates/patterns/molecules/listing/listing--image.yaml
+++ b/tbx/project_styleguide/templates/patterns/molecules/listing/listing--image.yaml
@@ -13,22 +13,22 @@ context:
 
 tags:
   image:
-    listing_image fill-370x370 format-webp as listing_desktop_image:
+    listing_image fill-370x370 format-webp saturation-0.6 as listing_desktop_image:
       target_var: listing_desktop_image
       raw:
         alt: 'desktop image'
         url: 'https://source.unsplash.com/370x370?trees'
-    listing_image fill-740x740 format-webp as listing_desktop_image_retina:
+    listing_image fill-740x740 format-webp saturation-0.6 as listing_desktop_image_retina:
       target_var: listing_desktop_image_retina
       raw:
         alt: 'desktop image retina'
         url: 'https://source.unsplash.com/740x740?trees'
-    listing_image fill-370x335 format-webp as listing_mobile_image:
+    listing_image fill-370x335 format-webp saturation-0.6 as listing_mobile_image:
       target_var: listing_mobile_image
       raw:
         alt: 'mobile image'
         url: 'https://source.unsplash.com/370x335?trees'
-    listing_image fill-740x670 format-webp as listing_mobile_image_retina:
+    listing_image fill-740x670 format-webp saturation-0.6 as listing_mobile_image_retina:
       target_var: listing_mobile_image_retina
       raw:
         alt: 'mobile image retina'

--- a/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/blog_chooser_block.yaml
+++ b/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/blog_chooser_block.yaml
@@ -44,17 +44,17 @@ tags:
     blog_page.blog_index as blog_index_url:
       raw: '/'
   image:
-    avatar fill-144x144 format-webp as avatar_desktop:
+    avatar fill-144x144 format-webp saturation-0.6 as avatar_desktop:
       target_var: avatar_desktop
       raw:
         alt: 'desktop image'
         url: 'https://source.unsplash.com/144x144?face'
-    avatar fill-286x286 format-webp as avatar_desktop_retina:
+    avatar fill-286x286 format-webp saturation-0.6 as avatar_desktop_retina:
       target_var: avatar_desktop_retina
       raw:
         alt: 'desktop image retina'
         url: 'https://source.unsplash.com/286x286?face'
-    avatar fill-72x72 format-webp as avatar_mobile:
+    avatar fill-72x72 format-webp saturation-0.6 as avatar_mobile:
       target_var: avatar_mobile
       raw:
         alt: 'mobile image'

--- a/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/contact_call_to_action.yaml
+++ b/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/contact_call_to_action.yaml
@@ -11,11 +11,11 @@ context:
 
 tags:
   image:
-    avatar fill-144x144 format-webp as avatar_desktop:
+    avatar fill-144x144 format-webp saturation-0.6 as avatar_desktop:
       target_var: avatar_desktop
       raw:
         url: 'https://source.unsplash.com/144x144?face'
-    avatar fill-72x72 format-webp as avatar_mobile:
+    avatar fill-72x72 format-webp saturation-0.6 as avatar_mobile:
       target_var: avatar_mobile
       raw:
         url: 'https://source.unsplash.com/72x72?face'

--- a/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/featured_case_study.html
+++ b/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/featured_case_study.html
@@ -4,7 +4,7 @@
     {# Image (with gradient if logo added) #}
     <div class="featured-case-study__image-wrap{% if value.featured_case_study_logo %} featured-case-study__image-wrap--with-logo{% endif %}">
 
-        {% srcset_image value.featured_case_study_image format-webp fill-{400x225,800x450,1600x900,1280x720} sizes="(max-width: 1022px) 90vw, (max-width: 1789px) 50vw, (min-width: 1800px) 1120px" class="featured-case-study__image" %}
+        {% srcset_image value.featured_case_study_image format-webp saturation-0.6 fill-{400x225,800x450,1600x900,1280x720} sizes="(max-width: 1022px) 90vw, (max-width: 1789px) 50vw, (min-width: 1800px) 1120px" class="featured-case-study__image" %}
 
         {# Optional logo #}
         {% if value.featured_case_study_logo %}

--- a/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/featured_case_study.yaml
+++ b/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/featured_case_study.yaml
@@ -13,7 +13,7 @@ context:
 
 tags:
   srcset_image:
-    'value.featured_case_study_image format-webp fill-{400x225,800x450,1600x900,1280x720} sizes="(max-width: 1022px) 90vw, (max-width: 1789px) 50vw, (min-width: 1800px) 1120px" class="featured-case-study__image"':
+    'value.featured_case_study_image format-webp saturation-0.6 fill-{400x225,800x450,1600x900,1280x720} sizes="(max-width: 1022px) 90vw, (max-width: 1789px) 50vw, (min-width: 1800px) 1120px" class="featured-case-study__image"':
       raw: '<img alt="Jeth-JulyImage_from_iOS" class="featured-case-study__image" height="225" sizes="(max-width: 1022px) 90vw, (max-width: 1789px) 50vw, (min-width: 1800px) 1120px" src="https://source.unsplash.com/400x225?tech" srcset="https://source.unsplash.com/400x225?tech 400w, https://source.unsplash.com/800x450?tech 800w, https://source.unsplash.com/1600x900?tech 1280w, https://source.unsplash.com/1280x720?tech 1280w" width="400">'
   image:
     value.featured_case_study_logo max-110x70 format-webp class="featured-case-study__company-logo":

--- a/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/image_block.html
+++ b/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/image_block.html
@@ -1,11 +1,11 @@
 {% load wagtailcore_tags wagtailimages_tags %}
 <div class="image grid__image">
     {% if value.image_is_decorative %}
-        {% srcset_image value.image format-webp fill-{400x225,800x450,1600x900,1280x720} sizes="(max-width: 1022px) 90vw, (max-width: 1879px) 70vw, (min-width: 1880px) 1170px" loading="lazy" alt="" %}
+        {% srcset_image value.image format-webp saturation-0.6 fill-{400x225,800x450,1600x900,1280x720} sizes="(max-width: 1022px) 90vw, (max-width: 1879px) 70vw, (min-width: 1880px) 1170px" loading="lazy" alt="" %}
     {% elif value.alt_text %}
-        {% srcset_image value.image format-webp fill-{400x225,800x450,1600x900,1280x720} sizes="(max-width: 1022px) 90vw, (max-width: 1879px) 70vw, (min-width: 1880px) 1170px" loading="lazy" alt=value.alt_text %}
+        {% srcset_image value.image format-webp saturation-0.6 fill-{400x225,800x450,1600x900,1280x720} sizes="(max-width: 1022px) 90vw, (max-width: 1879px) 70vw, (min-width: 1880px) 1170px" loading="lazy" alt=value.alt_text %}
     {% else %}
-        {% srcset_image value.image format-webp fill-{400x225,800x450,1600x900,1280x720} sizes="(max-width: 1022px) 90vw, (max-width: 1879px) 70vw, (min-width: 1880px) 1170px" loading="lazy" %}
+        {% srcset_image value.image format-webp saturation-0.6 fill-{400x225,800x450,1600x900,1280x720} sizes="(max-width: 1022px) 90vw, (max-width: 1879px) 70vw, (min-width: 1880px) 1170px" loading="lazy" %}
     {% endif %}
 
     {% if value.caption %}

--- a/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/image_block.yaml
+++ b/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/image_block.yaml
@@ -7,5 +7,5 @@ context:
 
 tags:
   srcset_image:
-    'value.image format-webp fill-{400x225,800x450,1600x900,1280x720} sizes="(max-width: 1022px) 90vw, (max-width: 1879px) 70vw, (min-width: 1880px) 1170px" loading="lazy" alt=value.alt_text':
+    'value.image format-webp saturation-0.6 fill-{400x225,800x450,1600x900,1280x720} sizes="(max-width: 1022px) 90vw, (max-width: 1879px) 70vw, (min-width: 1880px) 1170px" loading="lazy" alt=value.alt_text':
       raw: '<img alt="Screenshot of workshop to establish tone" height="225" sizes="(max-width: 1022px) 90vw, (max-width: 1879px) 70vw, (min-width: 1880px) 1170px" src="https://source.unsplash.com/400x225?trees" srcset="https://source.unsplash.com/400x225?trees 400w, https://source.unsplash.com/800x450?trees 800w, https://source.unsplash.com/1600x900?trees 1153w, https://source.unsplash.com/1280x720?trees 1153w" width="400">'

--- a/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/work_chooser_block.yaml
+++ b/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/work_chooser_block.yaml
@@ -37,22 +37,22 @@ tags:
     work_page.specific.work_index as work_index_url:
       raw: '/'
   image:
-    listing_image fill-370x370 format-webp as listing_desktop_image:
+    listing_image fill-370x370 format-webp saturation-0.6 as listing_desktop_image:
       target_var: listing_desktop_image
       raw:
         alt: 'desktop image'
         url: 'https://source.unsplash.com/370x370?trees'
-    listing_image fill-740x740 format-webp as listing_desktop_image_retina:
+    listing_image fill-740x740 format-webp saturation-0.6 as listing_desktop_image_retina:
       target_var: listing_desktop_image_retina
       raw:
         alt: 'desktop image retina'
         url: 'https://source.unsplash.com/740x740?trees'
-    listing_image fill-370x335 format-webp as listing_mobile_image:
+    listing_image fill-370x335 format-webp saturation-0.6 as listing_mobile_image:
       target_var: listing_mobile_image
       raw:
         alt: 'mobile image'
         url: 'https://source.unsplash.com/370x335?trees'
-    listing_image fill-740x670 format-webp as listing_mobile_image_retina:
+    listing_image fill-740x670 format-webp saturation-0.6 as listing_mobile_image_retina:
       target_var: listing_mobile_image_retina
       raw:
         alt: 'mobile image retina'

--- a/tbx/project_styleguide/templates/patterns/organisms/footer/footer.yaml
+++ b/tbx/project_styleguide/templates/patterns/organisms/footer/footer.yaml
@@ -34,19 +34,19 @@ context:
 
 tags:
   image:
-    avatar fill-144x144 format-webp as avatar_desktop:
+    avatar fill-144x144 format-webp saturation-0.6 as avatar_desktop:
       target_var: avatar_desktop
       raw:
         url: 'https://source.unsplash.com/144x144?face'
-    avatar fill-286x286 format-webp as avatar_desktop_retina:
+    avatar fill-286x286 format-webp saturation-0.6 as avatar_desktop_retina:
       target_var: avatar_desktop_retina
       raw:
         url: 'https://source.unsplash.com/286x286?face'
-    avatar fill-72x72 format-webp as avatar_mobile:
+    avatar fill-72x72 format-webp saturation-0.6 as avatar_mobile:
       target_var: avatar_mobile
       raw:
         url: 'https://source.unsplash.com/72x72?face'
-    logo.image max-100x100 format-webp loading="lazy" class="footer__logo" alt=link.text:
+    logo.image max-100x100 format-webp saturation-0.6 loading="lazy" class="footer__logo" alt=link.text:
       raw: |
         <img src="https://source.unsplash.com/100x100?logo" width="100" height="100" alt="test alt" class="footer__logo">
   footerlinks:

--- a/tbx/project_styleguide/templates/patterns/organisms/footer/footer.yaml
+++ b/tbx/project_styleguide/templates/patterns/organisms/footer/footer.yaml
@@ -33,19 +33,14 @@ context:
               image: fake
 
 tags:
+  srcset_image:
+    'avatar format-webp saturation-0.6 fill-{72x72,144x144,286x286} sizes="(max-width: 598px) 72px, (min-width: 599px) 145px" alt="" loading="lazy" class="avatar__image"':
+      raw: |
+        <img alt="" class="avatar__image" height="72" loading="lazy" sizes="(max-width: 598px) 72px, (min-width: 599px) 145px" src="https://source.unsplash.com/72x72?face" srcset="https://source.unsplash.com/72x72?face 72w, https://source.unsplash.com/144x144?face 144w, https://source.unsplash.com/286x286?face 286w" width="72">
+    'avatar format-webp saturation-0.6 fill-{72x72,144x144,286x286} sizes="(max-width: 598px) 72px, (min-width: 599px) 145px" alt="" class="avatar__image"':
+      raw: |
+        <img alt="" class="avatar__image" height="72" sizes="(max-width: 598px) 72px, (min-width: 599px) 145px" src="https://source.unsplash.com/72x72?face" srcset="https://source.unsplash.com/72x72?face 72w, https://source.unsplash.com/144x144?face 144w, https://source.unsplash.com/286x286?face 286w" width="72">
   image:
-    avatar fill-144x144 format-webp saturation-0.6 as avatar_desktop:
-      target_var: avatar_desktop
-      raw:
-        url: 'https://source.unsplash.com/144x144?face'
-    avatar fill-286x286 format-webp saturation-0.6 as avatar_desktop_retina:
-      target_var: avatar_desktop_retina
-      raw:
-        url: 'https://source.unsplash.com/286x286?face'
-    avatar fill-72x72 format-webp saturation-0.6 as avatar_mobile:
-      target_var: avatar_mobile
-      raw:
-        url: 'https://source.unsplash.com/72x72?face'
     logo.image max-100x100 format-webp saturation-0.6 loading="lazy" class="footer__logo" alt=link.text:
       raw: |
         <img src="https://source.unsplash.com/100x100?logo" width="100" height="100" alt="test alt" class="footer__logo">

--- a/tbx/project_styleguide/templates/patterns/pages/blog/blog_detail.yaml
+++ b/tbx/project_styleguide/templates/patterns/pages/blog/blog_detail.yaml
@@ -67,15 +67,15 @@ tags:
     page.body:
       template_name: 'patterns/molecules/streamfield/stream_block.html'
   image:
-    avatar fill-144x144 format-webp as avatar_desktop:
+    avatar fill-144x144 format-webp saturation-0.6 as avatar_desktop:
       target_var: avatar_desktop
       raw:
         url: 'https://source.unsplash.com/144x144?face'
-    avatar fill-286x286 format-webp as avatar_desktop_retina:
+    avatar fill-286x286 format-webp saturation-0.6 as avatar_desktop_retina:
       target_var: avatar_desktop_retina
       raw:
         url: 'https://source.unsplash.com/286x286?face'
-    avatar fill-72x72 format-webp as avatar_mobile:
+    avatar fill-72x72 format-webp saturation-0.6 as avatar_mobile:
       target_var: avatar_mobile
       raw:
         url: 'https://source.unsplash.com/72x72?face'

--- a/tbx/project_styleguide/templates/patterns/pages/blog/blog_detail.yaml
+++ b/tbx/project_styleguide/templates/patterns/pages/blog/blog_detail.yaml
@@ -66,19 +66,13 @@ tags:
   include_block:
     page.body:
       template_name: 'patterns/molecules/streamfield/stream_block.html'
-  image:
-    avatar fill-144x144 format-webp saturation-0.6 as avatar_desktop:
-      target_var: avatar_desktop
-      raw:
-        url: 'https://source.unsplash.com/144x144?face'
-    avatar fill-286x286 format-webp saturation-0.6 as avatar_desktop_retina:
-      target_var: avatar_desktop_retina
-      raw:
-        url: 'https://source.unsplash.com/286x286?face'
-    avatar fill-72x72 format-webp saturation-0.6 as avatar_mobile:
-      target_var: avatar_mobile
-      raw:
-        url: 'https://source.unsplash.com/72x72?face'
+  srcset_image:
+    'avatar format-webp saturation-0.6 fill-{72x72,144x144,286x286} sizes="(max-width: 598px) 72px, (min-width: 599px) 145px" alt="" loading="lazy" class="avatar__image"':
+      raw: |
+        <img alt="" class="avatar__image" height="72" loading="lazy" sizes="(max-width: 598px) 72px, (min-width: 599px) 145px" src="https://source.unsplash.com/72x72?face" srcset="https://source.unsplash.com/72x72?face 72w, https://source.unsplash.com/144x144?face 144w, https://source.unsplash.com/286x286?face 286w" width="72">
+    'avatar format-webp saturation-0.6 fill-{72x72,144x144,286x286} sizes="(max-width: 598px) 72px, (min-width: 599px) 145px" alt="" class="avatar__image"':
+      raw: |
+        <img alt="" class="avatar__image" height="72" sizes="(max-width: 598px) 72px, (min-width: 599px) 145px" src="https://source.unsplash.com/72x72?face" srcset="https://source.unsplash.com/72x72?face 72w, https://source.unsplash.com/144x144?face 144w, https://source.unsplash.com/286x286?face 286w" width="72">
   pageurl:
     page.blog_index as blog_index_url:
       raw: '#'

--- a/tbx/project_styleguide/templates/patterns/pages/blog/blog_listing.yaml
+++ b/tbx/project_styleguide/templates/patterns/pages/blog/blog_listing.yaml
@@ -91,17 +91,17 @@ context:
 
 tags:
   image:
-    avatar fill-144x144 format-webp as avatar_desktop:
+    avatar fill-144x144 format-webp saturation-0.6 as avatar_desktop:
       target_var: avatar_desktop
       raw:
         alt: 'desktop image'
         url: 'https://source.unsplash.com/144x144?face'
-    avatar fill-286x286 format-webp as avatar_desktop_retina:
+    avatar fill-286x286 format-webp saturation-0.6 as avatar_desktop_retina:
       target_var: avatar_desktop_retina
       raw:
         alt: 'desktop image retina'
         url: 'https://source.unsplash.com/286x286?face'
-    avatar fill-72x72 format-webp as avatar_mobile:
+    avatar fill-72x72 format-webp saturation-0.6 as avatar_mobile:
       target_var: avatar_mobile
       raw:
         alt: 'mobile image'

--- a/tbx/project_styleguide/templates/patterns/pages/team/team_detail.html
+++ b/tbx/project_styleguide/templates/patterns/pages/team/team_detail.html
@@ -17,7 +17,7 @@
         </div>
 
         <div class="image grid__team-image">
-            {% srcset_image page.image format-webp width-{400,650,950} sizes="(max-width: 598px) 400px, (max-width: 1022px) 950px, (min-width: 1023px) 650px" %}
+            {% srcset_image page.image format-webp saturation-0.6 width-{400,650,950} sizes="(max-width: 598px) 400px, (max-width: 1022px) 950px, (min-width: 1023px) 650px" %}
         </div>
 
         {% if page.intro %}

--- a/tbx/project_styleguide/templates/patterns/pages/team/team_detail.yaml
+++ b/tbx/project_styleguide/templates/patterns/pages/team/team_detail.yaml
@@ -41,7 +41,7 @@ context:
 
 tags:
   srcset_image:
-    'page.image format-webp width-{400,650,950} sizes="(max-width: 598px) 400px, (max-width: 1022px) 950px, (min-width: 1023px) 650px"':
+    'page.image format-webp saturation-0.6 width-{400,650,950} sizes="(max-width: 598px) 400px, (max-width: 1022px) 950px, (min-width: 1023px) 650px"':
       raw: '<img alt="" height="400" sizes="(max-width: 598px) 400px, (max-width: 1022px) 950px, (min-width: 1023px) 650px" src="https://source.unsplash.com/400x250/?person" srcset="https://source.unsplash.com/400x250/?person 400w, https://source.unsplash.com/650x406/?person 650w, https://source.unsplash.com/950x594/?person 950w" width="400">'
   footerlinks:
     '':

--- a/tbx/project_styleguide/templates/patterns/pages/team/team_detail.yaml
+++ b/tbx/project_styleguide/templates/patterns/pages/team/team_detail.yaml
@@ -50,22 +50,22 @@ tags:
     work_page.specific.work_index as work_index_url:
       raw: '/'
   image:
-    listing_image fill-370x370 format-webp as listing_desktop_image:
+    listing_image fill-370x370 format-webp saturation-0.6 as listing_desktop_image:
       target_var: listing_desktop_image
       raw:
         alt: 'desktop image'
         url: 'https://source.unsplash.com/370x370?trees'
-    listing_image fill-740x740 format-webp as listing_desktop_image_retina:
+    listing_image fill-740x740 format-webp saturation-0.6 as listing_desktop_image_retina:
       target_var: listing_desktop_image_retina
       raw:
         alt: 'desktop image retina'
         url: 'https://source.unsplash.com/740x740?trees'
-    listing_image fill-370x335 format-webp as listing_mobile_image:
+    listing_image fill-370x335 format-webp saturation-0.6 as listing_mobile_image:
       target_var: listing_mobile_image
       raw:
         alt: 'mobile image'
         url: 'https://source.unsplash.com/370x335?trees'
-    listing_image fill-740x670 format-webp as listing_mobile_image_retina:
+    listing_image fill-740x670 format-webp saturation-0.6 as listing_mobile_image_retina:
       target_var: listing_mobile_image_retina
       raw:
         alt: 'mobile image retina'

--- a/tbx/project_styleguide/templates/patterns/pages/team/team_listing.html
+++ b/tbx/project_styleguide/templates/patterns/pages/team/team_listing.html
@@ -10,9 +10,9 @@
                 <li class="team-listing__item">
                     {# lazy load after the first five #}
                     {% if forloop.counter > 5 %}
-                        {% srcset_image member.image format-webp fill-{230x230,370x370} sizes="(max-width: 598px) 370px, (min-width: 599px) 230px" class="team-listing__image" alt="" loading="lazy" %}
+                        {% srcset_image member.image format-webp saturation-0.6 fill-{230x230,370x370} sizes="(max-width: 598px) 370px, (min-width: 599px) 230px" class="team-listing__image" alt="" loading="lazy" %}
                     {% else %}
-                        {% srcset_image member.image format-webp fill-{230x230,370x370} sizes="(max-width: 598px) 370px, (min-width: 599px) 230px" class="team-listing__image" alt="" %}
+                        {% srcset_image member.image format-webp saturation-0.6 fill-{230x230,370x370} sizes="(max-width: 598px) 370px, (min-width: 599px) 230px" class="team-listing__image" alt="" %}
                     {% endif %}
                     <a class="team-listing__link" href="{{ member.url }}">
                         {{ member.title }}

--- a/tbx/project_styleguide/templates/patterns/pages/team/team_listing.yaml
+++ b/tbx/project_styleguide/templates/patterns/pages/team/team_listing.yaml
@@ -30,10 +30,10 @@ context:
 
 tags:
   srcset_image:
-    'member.image format-webp fill-{230x230,370x370} sizes="(max-width: 598px) 370px, (min-width: 599px) 230px" class="team-listing__image" alt=""':
+    'member.image format-webp saturation-0.6 fill-{230x230,370x370} sizes="(max-width: 598px) 370px, (min-width: 599px) 230px" class="team-listing__image" alt=""':
       raw: |
         <img alt="Abigail" class="team-listing__image" height="230" sizes="(max-width: 598px) 370px, (min-width: 599px) 230px" src="https://source.unsplash.com/230x230/?person" srcset="https://source.unsplash.com/230x230/?person 230w, https://source.unsplash.com/370x370/?person 370w" width="230">
-    'member.image format-webp fill-{230x230,370x370} sizes="(max-width: 598px) 370px, (min-width: 599px) 230px" class="team-listing__image" alt="" loading="lazy"':
+    'member.image format-webp saturation-0.6 fill-{230x230,370x370} sizes="(max-width: 598px) 370px, (min-width: 599px) 230px" class="team-listing__image" alt="" loading="lazy"':
       raw: |
         <img alt="Abigail" class="team-listing__image" height="230" sizes="(max-width: 598px) 370px, (min-width: 599px) 230px" src="https://source.unsplash.com/230x230/?person" srcset="https://source.unsplash.com/230x230/?person 230w, https://source.unsplash.com/370x370/?person 370w" width="230" loading="lazy">
 

--- a/tbx/project_styleguide/templates/patterns/pages/work/historical_work_page.yaml
+++ b/tbx/project_styleguide/templates/patterns/pages/work/historical_work_page.yaml
@@ -53,22 +53,22 @@ tags:
       template_name: 'patterns/molecules/streamfield/blocks/paragraph_block.html'
   image:
     # listing image for related pages
-    listing_image fill-370x370 format-webp as listing_desktop_image:
+    listing_image fill-370x370 format-webp saturation-0.6 as listing_desktop_image:
       target_var: listing_desktop_image
       raw:
         alt: 'desktop image'
         url: 'https://source.unsplash.com/370x370?trees'
-    listing_image fill-740x740 format-webp as listing_desktop_image_retina:
+    listing_image fill-740x740 format-webp saturation-0.6 as listing_desktop_image_retina:
       target_var: listing_desktop_image_retina
       raw:
         alt: 'desktop image retina'
         url: 'https://source.unsplash.com/740x740?trees'
-    listing_image fill-370x335 format-webp as listing_mobile_image:
+    listing_image fill-370x335 format-webp saturation-0.6 as listing_mobile_image:
       target_var: listing_mobile_image
       raw:
         alt: 'mobile image'
         url: 'https://source.unsplash.com/370x335?trees'
-    listing_image fill-740x670 format-webp as listing_mobile_image_retina:
+    listing_image fill-740x670 format-webp saturation-0.6 as listing_mobile_image_retina:
       target_var: listing_mobile_image_retina
       raw:
         alt: 'mobile image retina'

--- a/tbx/project_styleguide/templates/patterns/pages/work/historical_work_page.yaml
+++ b/tbx/project_styleguide/templates/patterns/pages/work/historical_work_page.yaml
@@ -51,6 +51,14 @@ tags:
       template_name: 'patterns/molecules/streamfield/blocks/intro_block.html'
     block:
       template_name: 'patterns/molecules/streamfield/blocks/paragraph_block.html'
+  # avatar image for authors
+  srcset_image:
+    'avatar format-webp saturation-0.6 fill-{72x72,144x144,286x286} sizes="(max-width: 598px) 72px, (min-width: 599px) 145px" alt="" loading="lazy" class="avatar__image"':
+      raw: |
+        <img alt="" class="avatar__image" height="72" loading="lazy" sizes="(max-width: 598px) 72px, (min-width: 599px) 145px" src="https://source.unsplash.com/72x72?face" srcset="https://source.unsplash.com/72x72?face 72w, https://source.unsplash.com/144x144?face 144w, https://source.unsplash.com/286x286?face 286w" width="72">
+    'avatar format-webp saturation-0.6 fill-{72x72,144x144,286x286} sizes="(max-width: 598px) 72px, (min-width: 599px) 145px" alt="" class="avatar__image"':
+      raw: |
+        <img alt="" class="avatar__image" height="72" sizes="(max-width: 598px) 72px, (min-width: 599px) 145px" src="https://source.unsplash.com/72x72?face" srcset="https://source.unsplash.com/72x72?face 72w, https://source.unsplash.com/144x144?face 144w, https://source.unsplash.com/286x286?face 286w" width="72">
   image:
     # listing image for related pages
     listing_image fill-370x370 format-webp saturation-0.6 as listing_desktop_image:
@@ -73,19 +81,6 @@ tags:
       raw:
         alt: 'mobile image retina'
         url: 'https://source.unsplash.com/740x670?trees'
-    # avatar image for authors
-    avatar fill-144x144 format-webp saturation-0.6 as avatar_desktop:
-      target_var: avatar_desktop
-      raw:
-        url: 'https://source.unsplash.com/144x144?face'
-    avatar fill-286x286 format-webp saturation-0.6 as avatar_desktop_retina:
-      target_var: avatar_desktop_retina
-      raw:
-        url: 'https://source.unsplash.com/286x286?face'
-    avatar fill-72x72 format-webp saturation-0.6 as avatar_mobile:
-      target_var: avatar_mobile
-      raw:
-        url: 'https://source.unsplash.com/72x72?face'
   pageurl:
     page.work_index as work_index_url:
       raw: '#'

--- a/tbx/project_styleguide/templates/patterns/pages/work/historical_work_page.yaml
+++ b/tbx/project_styleguide/templates/patterns/pages/work/historical_work_page.yaml
@@ -74,15 +74,15 @@ tags:
         alt: 'mobile image retina'
         url: 'https://source.unsplash.com/740x670?trees'
     # avatar image for authors
-    avatar fill-144x144 format-webp as avatar_desktop:
+    avatar fill-144x144 format-webp saturation-0.6 as avatar_desktop:
       target_var: avatar_desktop
       raw:
         url: 'https://source.unsplash.com/144x144?face'
-    avatar fill-286x286 format-webp as avatar_desktop_retina:
+    avatar fill-286x286 format-webp saturation-0.6 as avatar_desktop_retina:
       target_var: avatar_desktop_retina
       raw:
         url: 'https://source.unsplash.com/286x286?face'
-    avatar fill-72x72 format-webp as avatar_mobile:
+    avatar fill-72x72 format-webp saturation-0.6 as avatar_mobile:
       target_var: avatar_mobile
       raw:
         url: 'https://source.unsplash.com/72x72?face'

--- a/tbx/project_styleguide/templates/patterns/pages/work/work_index_page.yaml
+++ b/tbx/project_styleguide/templates/patterns/pages/work/work_index_page.yaml
@@ -80,22 +80,22 @@ context:
 
 tags:
   image:
-    listing_image fill-370x370 format-webp as listing_desktop_image:
+    listing_image fill-370x370 format-webp saturation-0.6 as listing_desktop_image:
       target_var: listing_desktop_image
       raw:
         alt: 'desktop image'
         url: 'https://source.unsplash.com/370x370?trees'
-    listing_image fill-740x740 format-webp as listing_desktop_image_retina:
+    listing_image fill-740x740 format-webp saturation-0.6 as listing_desktop_image_retina:
       target_var: listing_desktop_image_retina
       raw:
         alt: 'desktop image retina'
         url: 'https://source.unsplash.com/740x740?trees'
-    listing_image fill-370x335 format-webp as listing_mobile_image:
+    listing_image fill-370x335 format-webp saturation-0.6 as listing_mobile_image:
       target_var: listing_mobile_image
       raw:
         alt: 'mobile image'
         url: 'https://source.unsplash.com/370x335?trees'
-    listing_image fill-740x670 format-webp as listing_mobile_image_retina:
+    listing_image fill-740x670 format-webp saturation-0.6 as listing_mobile_image_retina:
       target_var: listing_mobile_image_retina
       raw:
         alt: 'mobile image retina'

--- a/tbx/project_styleguide/templates/patterns/pages/work/work_page.html
+++ b/tbx/project_styleguide/templates/patterns/pages/work/work_page.html
@@ -13,7 +13,7 @@
     <div class="grid">
         <div class="grid__work-image">
 
-            {% srcset_image page.header_image format-webp fill-{400x225,800x450,1600x900,1280x720} sizes="(max-width: 1799px) 90vw, (min-width: 1800px) 1680px" loading="lazy" %}
+            {% srcset_image page.header_image format-webp saturation-0.6 fill-{400x225,800x450,1600x900,1280x720} sizes="(max-width: 1799px) 90vw, (min-width: 1800px) 1680px" loading="lazy" %}
 
             {% if page.header_caption %}
                 <p class="image__caption supporting">{{ page.header_caption }}</p>

--- a/tbx/project_styleguide/templates/patterns/pages/work/work_page.yaml
+++ b/tbx/project_styleguide/templates/patterns/pages/work/work_page.yaml
@@ -44,8 +44,11 @@ tags:
   include_block:
     page.body:
       template_name: 'patterns/molecules/streamfield/blocks/work_section_block.html'
-  # avatar image for authors
   srcset_image:
+    # header image
+    'page.header_image format-webp  saturation-0.6 fill-{400x225,800x450,1600x900,1280x720} sizes="(max-width: 1799px) 90vw, (min-width: 1800px) 1680px" loading="lazy"':
+      raw: '<img alt="" height="225" loading="lazy" sizes="(max-width: 1799px) 90vw, (min-width: 1800px) 1680px" src="https://source.unsplash.com/400x225?trees" srcset="https://source.unsplash.com/400x225?trees 400w, https://source.unsplash.com/800x450?trees 800w, https://source.unsplash.com/1600x900?trees 1254w, https://source.unsplash.com/1280x720?trees 1254w" width="400">'
+    # avatar image for authors
     'avatar format-webp saturation-0.6 fill-{72x72,144x144,286x286} sizes="(max-width: 598px) 72px, (min-width: 599px) 145px" alt="" loading="lazy" class="avatar__image"':
       raw: |
         <img alt="" class="avatar__image" height="72" loading="lazy" sizes="(max-width: 598px) 72px, (min-width: 599px) 145px" src="https://source.unsplash.com/72x72?face" srcset="https://source.unsplash.com/72x72?face 72w, https://source.unsplash.com/144x144?face 144w, https://source.unsplash.com/286x286?face 286w" width="72">
@@ -77,11 +80,6 @@ tags:
       raw:
         alt: 'mobile image retina'
         url: 'https://source.unsplash.com/740x670?trees'
-
-  # header image
-  srcset_image:
-    'page.header_image format-webp  saturation-0.6 fill-{400x225,800x450,1600x900,1280x720} sizes="(max-width: 1799px) 90vw, (min-width: 1800px) 1680px" loading="lazy"':
-      raw: '<img alt="" height="225" loading="lazy" sizes="(max-width: 1799px) 90vw, (min-width: 1800px) 1680px" src="https://source.unsplash.com/400x225?trees" srcset="https://source.unsplash.com/400x225?trees 400w, https://source.unsplash.com/800x450?trees 800w, https://source.unsplash.com/1600x900?trees 1254w, https://source.unsplash.com/1280x720?trees 1254w" width="400">'
   footerlinks:
     '':
       template_name: 'patterns/navigation/components/footer-links.html'

--- a/tbx/project_styleguide/templates/patterns/pages/work/work_page.yaml
+++ b/tbx/project_styleguide/templates/patterns/pages/work/work_page.yaml
@@ -70,15 +70,15 @@ tags:
         alt: 'mobile image retina'
         url: 'https://source.unsplash.com/740x670?trees'
     # avatar image for authors
-    avatar fill-144x144 format-webp as avatar_desktop:
+    avatar fill-144x144 format-webp saturation-0.6 as avatar_desktop:
       target_var: avatar_desktop
       raw:
         url: 'https://source.unsplash.com/144x144?face'
-    avatar fill-286x286 format-webp as avatar_desktop_retina:
+    avatar fill-286x286 format-webp saturation-0.6 as avatar_desktop_retina:
       target_var: avatar_desktop_retina
       raw:
         url: 'https://source.unsplash.com/286x286?face'
-    avatar fill-72x72 format-webp as avatar_mobile:
+    avatar fill-72x72 format-webp saturation-0.6 as avatar_mobile:
       target_var: avatar_mobile
       raw:
         url: 'https://source.unsplash.com/72x72?face'

--- a/tbx/project_styleguide/templates/patterns/pages/work/work_page.yaml
+++ b/tbx/project_styleguide/templates/patterns/pages/work/work_page.yaml
@@ -44,6 +44,14 @@ tags:
   include_block:
     page.body:
       template_name: 'patterns/molecules/streamfield/blocks/work_section_block.html'
+  # avatar image for authors
+  srcset_image:
+    'avatar format-webp saturation-0.6 fill-{72x72,144x144,286x286} sizes="(max-width: 598px) 72px, (min-width: 599px) 145px" alt="" loading="lazy" class="avatar__image"':
+      raw: |
+        <img alt="" class="avatar__image" height="72" loading="lazy" sizes="(max-width: 598px) 72px, (min-width: 599px) 145px" src="https://source.unsplash.com/72x72?face" srcset="https://source.unsplash.com/72x72?face 72w, https://source.unsplash.com/144x144?face 144w, https://source.unsplash.com/286x286?face 286w" width="72">
+    'avatar format-webp saturation-0.6 fill-{72x72,144x144,286x286} sizes="(max-width: 598px) 72px, (min-width: 599px) 145px" alt="" class="avatar__image"':
+      raw: |
+        <img alt="" class="avatar__image" height="72" sizes="(max-width: 598px) 72px, (min-width: 599px) 145px" src="https://source.unsplash.com/72x72?face" srcset="https://source.unsplash.com/72x72?face 72w, https://source.unsplash.com/144x144?face 144w, https://source.unsplash.com/286x286?face 286w" width="72">
   image:
     # client logo
     page.logo width-175 format-webp class="work-hero__logo":
@@ -69,19 +77,6 @@ tags:
       raw:
         alt: 'mobile image retina'
         url: 'https://source.unsplash.com/740x670?trees'
-    # avatar image for authors
-    avatar fill-144x144 format-webp saturation-0.6 as avatar_desktop:
-      target_var: avatar_desktop
-      raw:
-        url: 'https://source.unsplash.com/144x144?face'
-    avatar fill-286x286 format-webp saturation-0.6 as avatar_desktop_retina:
-      target_var: avatar_desktop_retina
-      raw:
-        url: 'https://source.unsplash.com/286x286?face'
-    avatar fill-72x72 format-webp saturation-0.6 as avatar_mobile:
-      target_var: avatar_mobile
-      raw:
-        url: 'https://source.unsplash.com/72x72?face'
 
   # header image
   srcset_image:

--- a/tbx/project_styleguide/templates/patterns/pages/work/work_page.yaml
+++ b/tbx/project_styleguide/templates/patterns/pages/work/work_page.yaml
@@ -49,22 +49,22 @@ tags:
     page.logo width-175 format-webp class="work-hero__logo":
       raw: '<img src="https://source.unsplash.com/175x100/?logo" class="work-hero__logo">'
     # listing image for related pages
-    listing_image fill-370x370 format-webp as listing_desktop_image:
+    listing_image fill-370x370 format-webp saturation-0.6 as listing_desktop_image:
       target_var: listing_desktop_image
       raw:
         alt: 'desktop image'
         url: 'https://source.unsplash.com/370x370?trees'
-    listing_image fill-740x740 format-webp as listing_desktop_image_retina:
+    listing_image fill-740x740 format-webp saturation-0.6 as listing_desktop_image_retina:
       target_var: listing_desktop_image_retina
       raw:
         alt: 'desktop image retina'
         url: 'https://source.unsplash.com/740x740?trees'
-    listing_image fill-370x335 format-webp as listing_mobile_image:
+    listing_image fill-370x335 format-webp saturation-0.6 as listing_mobile_image:
       target_var: listing_mobile_image
       raw:
         alt: 'mobile image'
         url: 'https://source.unsplash.com/370x335?trees'
-    listing_image fill-740x670 format-webp as listing_mobile_image_retina:
+    listing_image fill-740x670 format-webp saturation-0.6 as listing_mobile_image_retina:
       target_var: listing_mobile_image_retina
       raw:
         alt: 'mobile image retina'

--- a/tbx/project_styleguide/templates/patterns/pages/work/work_page.yaml
+++ b/tbx/project_styleguide/templates/patterns/pages/work/work_page.yaml
@@ -85,7 +85,7 @@ tags:
 
   # header image
   srcset_image:
-    'page.header_image format-webp fill-{400x225,800x450,1600x900,1280x720} sizes="(max-width: 1799px) 90vw, (min-width: 1800px) 1680px" loading="lazy"':
+    'page.header_image format-webp  saturation-0.6 fill-{400x225,800x450,1600x900,1280x720} sizes="(max-width: 1799px) 90vw, (min-width: 1800px) 1680px" loading="lazy"':
       raw: '<img alt="" height="225" loading="lazy" sizes="(max-width: 1799px) 90vw, (min-width: 1800px) 1680px" src="https://source.unsplash.com/400x225?trees" srcset="https://source.unsplash.com/400x225?trees 400w, https://source.unsplash.com/800x450?trees 800w, https://source.unsplash.com/1600x900?trees 1254w, https://source.unsplash.com/1280x720?trees 1254w" width="400">'
   footerlinks:
     '':

--- a/tbx/project_styleguide/templates/patterns/styleguide/components/components.yaml
+++ b/tbx/project_styleguide/templates/patterns/styleguide/components/components.yaml
@@ -79,20 +79,14 @@ tags:
     # Featured case study
     'value.featured_case_study_image format-webp saturation-0.6 fill-{400x225,800x450,1600x900,1280x720} sizes="(max-width: 1022px) 90vw, (max-width: 1789px) 50vw, (min-width: 1800px) 1120px" class="featured-case-study__image"':
       raw: '<img alt="Jeth-JulyImage_from_iOS" class="featured-case-study__image" height="225" sizes="(max-width: 1022px) 90vw, (max-width: 1789px) 50vw, (min-width: 1800px) 1120px" src="https://source.unsplash.com/400x225?tech" srcset="https://source.unsplash.com/400x225?tech 400w, https://source.unsplash.com/800x450?tech 800w, https://source.unsplash.com/1600x900?tech 1280w, https://source.unsplash.com/1280x720?tech 1280w" width="400">'
-  image:
     # avatar image variants
-    avatar fill-144x144 format-webp saturation-0.6 as avatar_desktop:
-      target_var: avatar_desktop
-      raw:
-        url: 'https://source.unsplash.com/144x144?face'
-    avatar fill-286x286 format-webp saturation-0.6 as avatar_desktop_retina:
-      target_var: avatar_desktop_retina
-      raw:
-        url: 'https://source.unsplash.com/286x286?face'
-    avatar fill-72x72 format-webp saturation-0.6 as avatar_mobile:
-      target_var: avatar_mobile
-      raw:
-        url: 'https://source.unsplash.com/72x72?face'
+    'avatar format-webp saturation-0.6 fill-{72x72,144x144,286x286} sizes="(max-width: 598px) 72px, (min-width: 599px) 145px" alt="" loading="lazy" class="avatar__image"':
+      raw: |
+        <img alt="" class="avatar__image" height="72" loading="lazy" sizes="(max-width: 598px) 72px, (min-width: 599px) 145px" src="https://source.unsplash.com/72x72?face" srcset="https://source.unsplash.com/72x72?face 72w, https://source.unsplash.com/144x144?face 144w, https://source.unsplash.com/286x286?face 286w" width="72">
+    'avatar format-webp saturation-0.6 fill-{72x72,144x144,286x286} sizes="(max-width: 598px) 72px, (min-width: 599px) 145px" alt="" class="avatar__image"':
+      raw: |
+        <img alt="" class="avatar__image" height="72" sizes="(max-width: 598px) 72px, (min-width: 599px) 145px" src="https://source.unsplash.com/72x72?face" srcset="https://source.unsplash.com/72x72?face 72w, https://source.unsplash.com/144x144?face 144w, https://source.unsplash.com/286x286?face 286w" width="72">
+  image:
     # company logo for pull quote
     value.logo max-110x70 format-webp class="pullquote__company-logo":
       raw: |

--- a/tbx/project_styleguide/templates/patterns/styleguide/components/components.yaml
+++ b/tbx/project_styleguide/templates/patterns/styleguide/components/components.yaml
@@ -81,15 +81,15 @@ tags:
       raw: '<img alt="Jeth-JulyImage_from_iOS" class="featured-case-study__image" height="225" sizes="(max-width: 1022px) 90vw, (max-width: 1789px) 50vw, (min-width: 1800px) 1120px" src="https://source.unsplash.com/400x225?tech" srcset="https://source.unsplash.com/400x225?tech 400w, https://source.unsplash.com/800x450?tech 800w, https://source.unsplash.com/1600x900?tech 1280w, https://source.unsplash.com/1280x720?tech 1280w" width="400">'
   image:
     # avatar image variants
-    avatar fill-144x144 format-webp as avatar_desktop:
+    avatar fill-144x144 format-webp saturation-0.6 as avatar_desktop:
       target_var: avatar_desktop
       raw:
         url: 'https://source.unsplash.com/144x144?face'
-    avatar fill-286x286 format-webp as avatar_desktop_retina:
+    avatar fill-286x286 format-webp saturation-0.6 as avatar_desktop_retina:
       target_var: avatar_desktop_retina
       raw:
         url: 'https://source.unsplash.com/286x286?face'
-    avatar fill-72x72 format-webp as avatar_mobile:
+    avatar fill-72x72 format-webp saturation-0.6 as avatar_mobile:
       target_var: avatar_mobile
       raw:
         url: 'https://source.unsplash.com/72x72?face'

--- a/tbx/project_styleguide/templates/patterns/styleguide/components/components.yaml
+++ b/tbx/project_styleguide/templates/patterns/styleguide/components/components.yaml
@@ -74,10 +74,10 @@ tags:
       raw: '#'
   srcset_image:
     # Image block
-    'value.image format-webp fill-{400x225,800x450,1600x900,1280x720} sizes="(max-width: 1022px) 90vw, (max-width: 1879px) 70vw, (min-width: 1880px) 1170px" loading="lazy" alt=value.alt_text':
+    'value.image format-webp saturation-0.6 fill-{400x225,800x450,1600x900,1280x720} sizes="(max-width: 1022px) 90vw, (max-width: 1879px) 70vw, (min-width: 1880px) 1170px" loading="lazy" alt=value.alt_text':
       raw: '<img alt="Screenshot of workshop to establish tone" height="225" sizes="(max-width: 1022px) 90vw, (max-width: 1879px) 70vw, (min-width: 1880px) 1170px" src="https://source.unsplash.com/400x225?trees" srcset="https://source.unsplash.com/400x225?trees 400w, https://source.unsplash.com/800x450?trees 800w, https://source.unsplash.com/1600x900?trees 1153w, https://source.unsplash.com/1280x720?trees 1153w" width="400">'
     # Featured case study
-    'value.featured_case_study_image format-webp fill-{400x225,800x450,1600x900,1280x720} sizes="(max-width: 1022px) 90vw, (max-width: 1789px) 50vw, (min-width: 1800px) 1120px" class="featured-case-study__image"':
+    'value.featured_case_study_image format-webp saturation-0.6 fill-{400x225,800x450,1600x900,1280x720} sizes="(max-width: 1022px) 90vw, (max-width: 1789px) 50vw, (min-width: 1800px) 1120px" class="featured-case-study__image"':
       raw: '<img alt="Jeth-JulyImage_from_iOS" class="featured-case-study__image" height="225" sizes="(max-width: 1022px) 90vw, (max-width: 1789px) 50vw, (min-width: 1800px) 1120px" src="https://source.unsplash.com/400x225?tech" srcset="https://source.unsplash.com/400x225?tech 400w, https://source.unsplash.com/800x450?tech 800w, https://source.unsplash.com/1600x900?tech 1280w, https://source.unsplash.com/1280x720?tech 1280w" width="400">'
   image:
     # avatar image variants
@@ -98,22 +98,22 @@ tags:
       raw: |
         <img src="https://source.unsplash.com/110x70?logo" width="110" height="70" alt="Some alt" class="pullquote__company-logo">
     # listing image variants
-    listing_image fill-370x370 format-webp as listing_desktop_image:
+    listing_image fill-370x370 format-webp saturation-0.6 as listing_desktop_image:
       target_var: listing_desktop_image
       raw:
         alt: 'desktop image'
         url: 'https://source.unsplash.com/370x370?trees'
-    listing_image fill-740x740 format-webp as listing_desktop_image_retina:
+    listing_image fill-740x740 format-webp saturation-0.6 as listing_desktop_image_retina:
       target_var: listing_desktop_image_retina
       raw:
         alt: 'desktop image retina'
         url: 'https://source.unsplash.com/740x740?trees'
-    listing_image fill-370x335 format-webp as listing_mobile_image:
+    listing_image fill-370x335 format-webp saturation-0.6 as listing_mobile_image:
       target_var: listing_mobile_image
       raw:
         alt: 'mobile image'
         url: 'https://source.unsplash.com/370x335?trees'
-    listing_image fill-740x670 format-webp as listing_mobile_image_retina:
+    listing_image fill-740x670 format-webp saturation-0.6 as listing_mobile_image_retina:
       target_var: listing_mobile_image_retina
       raw:
         alt: 'mobile image retina'


### PR DESCRIPTION
[Link to Ticket](https://torchbox.monday.com/boards/1192293412/pulses/1388897849)

### Description of Changes Made

- Make all images desaturated by 40%
- Convert avatar images to use the `srcset_image` tag (listing images have some art direction involved so I have left these as picture tags)

Note: this will necessitate all image renditions being recreated, so we may have further problems with the team page listing on staging and production until they are re-created again.

### How to Test

View any page with an image in an actual wagtail build - pattern library images should still render but will not be desaturated.

### Screenshots

<details>
  <summary>Expand to see more</summary>

Featured case study example
![Screenshot 2024-02-26 at 12 23 45](https://github.com/torchbox/torchbox.com/assets/771869/d7b9b17c-e592-443a-9b4b-da7dd9759aa3)

</details>

### MR Checklist

- [x] Add a description of your pull request and instructions for the reviewer to verify your work.
- [x] If your pull request is for a specific ticket, link to it in the description.
- [x] Stay on point and keep it small so the merge request can be easily reviewed.
- [ ] Tests and linting passes.

#### Unit tests

- [ ] Added
- [x] Not required

#### Documentation

- [x] Updated build docs
- [x] Updated editor guidelines (https://docs.google.com/document/d/1PAWccdQ4tfaZsrEWmpDhvP3GH5RRmBOARFVp4b-kje8/edit?usp=sharing)
- [ ] Not required

#### Browser testing

- [x] I have tested in the following browsers and environments (edit the list as required)
  - Latest version of Chrome on mac
- [ ] Not required

#### Data protection

- [x] Not relevant
- [ ] This adds new sources of PII and documents it and modifies Birdbath processors accordingly

#### Accessibility

- [ ] Automated WCAG 2.1 tests pass
- [ ] Manual WCAG 2.1 tests completed
- [ ] I have tested in a screen reader
- [ ] I have tested in high-contrast mode
- [ ] Any animations removed for prefers-reduced-motion
- [x] Not required

#### Sustainability

- [x] Images are optimised and lazy-loading used where appropriate
- [ ] SVGs have been optimised
- [x] Perfomance and transfer of data considered
- [ ] If JavaScript is needed alternatives have been considered
- [ ] Not required

#### Pattern library

- [x] The pattern library component for this template displays correctly, and does not break parent templates
- [x] The styleguide is updated if relevant
- [ ] Changes are not relevant the pattern library
