### PR TITLE
Fix Sentry error on Production - Image Size

### DIFF
--- a/tbx/settings/base.py
+++ b/tbx/settings/base.py
@@ -446,6 +446,10 @@ if "PRIMARY_HOST" in env:
 # Override the Image class used by wagtailimages with a custom one
 WAGTAILIMAGES_IMAGE_MODEL = "images.CustomImage"
 
+pixel_limit = env.get("WAGTAILIMAGES_MAX_IMAGE_PIXELS")
+WAGTAILIMAGES_MAX_IMAGE_PIXELS = int(pixel_limit) if pixel_limit else 10_000_000
+
+
 # Facebook JSSDK app Id
 FB_APP_ID = ""
 


### PR DESCRIPTION
This is following a series of Sentry errors of type;
    `Error R15 (Memory quota vastly exceeded)`

This fix was also implemented by Kevin H on CUH https://git.torchbox.com/cuh/cuhconnect/-/merge_requests/196

[Link to Ticket](https://torchbox.monday.com/boards/1192293412/pulses/1405112378)

### Description of Changes Made
Include a pixel_limit to base.py to warn editors when they upload an image which is likely to cause production errors.

### How to Test
- Confirm that when uploading an image greater than 10,000,000 pixels, an editor warning is shown.
Once this has been approved, we could implement this to production to reduce the likelihood of these errors happening in future.

We should also delete any existing large images in the image library

### Screenshots
<img width="741" alt="Choose an image" src="https://github.com/torchbox/torchbox.com/assets/68611528/60e46bd6-507f-4046-99f0-3cbe85e194d0">

<details>
  <summary>Expand to see more</summary>

</details>

### MR Checklist

- [x] Add a description of your pull request and instructions for the reviewer to verify your work.
- [x] If your pull request is for a specific ticket, link to it in the description.
- [x] Stay on point and keep it small so the merge request can be easily reviewed.
- [x] Tests and linting passes.

#### Unit tests

- [ ] Added
- [x] Not required

#### Documentation

- [ ] Updated build docs
- [ ] Updated editor guidelines (https://docs.google.com/document/d/1PAWccdQ4tfaZsrEWmpDhvP3GH5RRmBOARFVp4b-kje8/edit?usp=sharing)
- [x] Not required

#### Browser testing

- [ ] I have tested in the following browsers and environments (edit the list as required)
  - Latest version of Chrome on mac
  - Latest version of Firefox on mac
  - Latest version of Safari on mac
  - Safari on last two versions of iOS
  - Chrome on last two versions of Android
- [x] Not required

#### Data protection

- [x] Not relevant
- [ ] This adds new sources of PII and documents it and modifies Birdbath processors accordingly

#### Accessibility

- [ ] Automated WCAG 2.1 tests pass
- [ ] Manual WCAG 2.1 tests completed
- [ ] I have tested in a screen reader
- [ ] I have tested in high-contrast mode
- [ ] Any animations removed for prefers-reduced-motion
- [x] Not required

#### Sustainability

- [ ] Images are optimised and lazy-loading used where appropriate
- [ ] SVGs have been optimised
- [ ] Perfomance and transfer of data considered
- [ ] If JavaScript is needed alternatives have been considered
- [x] Not required

#### Pattern library

- [ ] The pattern library component for this template displays correctly, and does not break parent templates
- [ ] The styleguide is updated if relevant
- [x] Changes are not relevant the pattern library
