### PR TITLE
Limit memory usage when loading files from S3

### DIFF
--- a/tbx/settings/base.py
+++ b/tbx/settings/base.py
@@ -214,6 +214,7 @@ if "AWS_STORAGE_BUCKET_NAME" in env:
     AWS_STORAGE_BUCKET_NAME = env["AWS_STORAGE_BUCKET_NAME"]
     AWS_QUERYSTRING_AUTH = False
     AWS_S3_FILE_OVERWRITE = False
+    AWS_S3_MAX_MEMORY_SIZE = 2 * 1024 * 1024  # 2MB
 
     # You need this to enable signing files. Some old regions may have use a
     # different version than v4.


### PR DESCRIPTION
### Description of Changes Made

By default, files are always loaded into memory, regardless of their size. Now, files larger than 2MB are saves to disk instead.

I've also made a change upstream to change the default: https://github.com/jschneier/django-storages/pull/1359/

### How to Test

### Screenshots

### MR Checklist

- [x] Add a description of your pull request and instructions for the reviewer to verify your work.
- [ ] If your pull request is for a specific ticket, link to it in the description.
- [x] Stay on point and keep it small so the merge request can be easily reviewed.
- [x] Tests and linting passes.

#### Unit tests

- [ ] Added
- [x] Not required

#### Documentation

- [ ] Updated build docs
- [ ] Updated editor guidelines (https://docs.google.com/document/d/1PAWccdQ4tfaZsrEWmpDhvP3GH5RRmBOARFVp4b-kje8/edit?usp=sharing)
- [x] Not required

#### Browser testing

- [ ] I have tested in the following browsers and environments (edit the list as required)
  - Latest version of Chrome on mac
  - Latest version of Firefox on mac
  - Latest version of Safari on mac
  - Safari on last two versions of iOS
  - Chrome on last two versions of Android
- [x] Not required

#### Data protection

- [x] Not relevant
- [ ] This adds new sources of PII and documents it and modifies Birdbath processors accordingly

#### Accessibility

- [ ] Automated WCAG 2.1 tests pass
- [ ] Manual WCAG 2.1 tests completed
- [ ] I have tested in a screen reader
- [ ] I have tested in high-contrast mode
- [ ] Any animations removed for prefers-reduced-motion
- [x] Not required

#### Sustainability

- [ ] Images are optimised and lazy-loading used where appropriate
- [ ] SVGs have been optimised
- [x] Perfomance and transfer of data considered
- [ ] If JavaScript is needed alternatives have been considered
- [ ] Not required

#### Pattern library

- [ ] The pattern library component for this template displays correctly, and does not break parent templates
- [ ] The styleguide is updated if relevant
- [x] Changes are not relevant the pattern library
