### PR TITLE
Use eval() not int() to interpret the max upload size

### DIFF
--- a/tbx/settings/base.py
+++ b/tbx/settings/base.py
@@ -452,7 +452,7 @@ WAGTAILIMAGES_MAX_IMAGE_PIXELS = int(pixel_limit) if pixel_limit else 10_000_000
 
 max_upload_size = env.get("WAGTAILIMAGES_MAX_UPLOAD_SIZE")
 WAGTAILIMAGES_MAX_UPLOAD_SIZE = (
-    int(max_upload_size) if max_upload_size else 2 * 1024 * 1024
+    eval(max_upload_size) if max_upload_size else 2 * 1024 * 1024
 )  # 2MB
 
 # Facebook JSSDK app Id


### PR DESCRIPTION
[Link to Ticket]()

### Description of Changes Made

This is a hotifx for a bug deploying to production. We can't use `int()` to evaluate the string `2 * 1024 * 1024` - we need to use `eval()` to calculate the result instead. I have tested that the result is an integer.

### How to Test

### Screenshots

<details>
  <summary>Expand to see more</summary>

</details>

### MR Checklist

- [x] Add a description of your pull request and instructions for the reviewer to verify your work.
- [x] If your pull request is for a specific ticket, link to it in the description.
- [x] Stay on point and keep it small so the merge request can be easily reviewed.
- [x] Tests and linting passes.

#### Unit tests

- [ ] Added
- [x] Not required

#### Documentation

- [ ] Updated build docs
- [ ] Updated editor guidelines (https://docs.google.com/document/d/1PAWccdQ4tfaZsrEWmpDhvP3GH5RRmBOARFVp4b-kje8/edit?usp=sharing)
- [x] Not required

#### Browser testing

- [ ] I have tested in the following browsers and environments (edit the list as required)
  - Latest version of Chrome on mac
  - Latest version of Firefox on mac
  - Latest version of Safari on mac
  - Safari on last two versions of iOS
  - Chrome on last two versions of Android
- [x] Not required

#### Data protection

- [x] Not relevant
- [ ] This adds new sources of PII and documents it and modifies Birdbath processors accordingly

#### Accessibility

- [ ] Automated WCAG 2.1 tests pass
- [ ] Manual WCAG 2.1 tests completed
- [ ] I have tested in a screen reader
- [ ] I have tested in high-contrast mode
- [ ] Any animations removed for prefers-reduced-motion
- [x] Not required

#### Sustainability

- [ ] Images are optimised and lazy-loading used where appropriate
- [ ] SVGs have been optimised
- [ ] Perfomance and transfer of data considered
- [ ] If JavaScript is needed alternatives have been considered
- [x] Not required

#### Pattern library

- [ ] The pattern library component for this template displays correctly, and does not break parent templates
- [ ] The styleguide is updated if relevant
- [x] Changes are not relevant the pattern library
