### PR TITLE
Fix to ensure a PersonPage exists and is published before we can link to them

### DIFF
--- a/tbx/people/factories.py
+++ b/tbx/people/factories.py
@@ -150,12 +150,21 @@ class ContactReasonsListFactory(DjangoModelFactory):
     """
     Factory for generating ContactReasonsList instances along with
     related ContactReason instances.
+
     *Usage*:
-    Create a ContactReasonsList instance without related reasons:
-    `contact_reasons_list = ContactReasonsListFactory()`
-    Create a ContactReasonsList instance with a specific number of
+
+    1. Create a ContactReasonsList instance without related reasons:
+
+    ```
+    contact_reasons_list = ContactReasonsListFactory()
+    ```
+
+    2. Create a ContactReasonsList instance with a specific number of
     related ContactReason instances:
-    `contact_reasons_list_with_reasons = ContactReasonsListFactory(reasons=3)`
+
+    ```
+    contact_reasons_list_with_reasons = ContactReasonsListFactory(reasons=3)
+    ```
     """
 
     name = factory.Faker("text", max_nb_chars=20)

--- a/tbx/people/factories.py
+++ b/tbx/people/factories.py
@@ -2,13 +2,24 @@ import json
 import logging
 
 import factory
+import wagtail_factories
 from factory.django import DjangoModelFactory
 from faker import Faker
 from tbx.core.factories import StandardPageFactory
 from tbx.core.models import HomePage
 from tbx.images.factories import CustomImageFactory
-from tbx.people.models import Contact, ContactReason, ContactReasonsList
+from tbx.people.models import (
+    Author,
+    Contact,
+    ContactReason,
+    ContactReasonsList,
+    PersonIndexPage,
+    PersonPage,
+)
+from tbx.taxonomy.factories import TeamFactory
+from tbx.taxonomy.models import Team
 
+faker = Faker(["en_GB"])
 logger = logging.getLogger(__name__)
 
 
@@ -99,8 +110,6 @@ class ContactFactory(DjangoModelFactory):
                     "Page argument ignored because link type is not 'internal_link'"
                 )
 
-            faker = Faker(["en_GB"])
-
             cta_value = {
                 "type": "call_to_action",
                 "value": {
@@ -165,3 +174,82 @@ class ContactReasonsListFactory(DjangoModelFactory):
                 ContactReasonFactory.create_batch(extracted, page=self)
             else:
                 raise ValueError("The 'reasons' field expects an integer value.")
+
+
+class AuthorFactory(DjangoModelFactory):
+    name = factory.Faker("name")
+    role = factory.Faker("job")
+    image = factory.SubFactory(CustomImageFactory)
+
+    class Meta:
+        model = Author
+
+
+class PersonIndexPageFactory(wagtail_factories.PageFactory):
+    title = factory.Faker("text", max_nb_chars=12)
+    strapline = factory.Faker("text", max_nb_chars=100)
+
+    class Meta:
+        model = PersonIndexPage
+
+
+class PersonPageFactory(wagtail_factories.PageFactory):
+    """
+    Factory for generating `PersonPage` instances.
+    By default, this factory will create a PersonPage instance with a related team.
+
+    You can optionally either specify the name of the related team or a
+    `tbx.taxonomy.models.Team` instance. Please see below for some examples.
+
+
+    **Usage examples**
+
+    1. Create a PersonPage instance with a random related team:
+
+    ```
+    >>> person = PersonPageFactory()
+    >>> person.related_teams.all()
+    <QuerySet [<Team: Spend can white.>]>
+    ```
+
+    2. Create a PersonPage instance with a specific related team:
+
+    ```
+    >>> team = TeamFactory(name="Foo")
+    >>> person = PersonPageFactory(related_teams=team)
+    >>> person.related_teams.all()
+    <QuerySet [<Team: Foo>]>
+    ```
+
+    3. Create a PersonPage instance specifying the name of the related team:
+
+    ```
+    >>> person = PersonPageFactory(related_teams="Foo Bar")
+    >>> person.related_teams.all()
+    <QuerySet [<Team: Foo Bar>]>
+    ```
+    """
+
+    title = factory.Faker("name")
+    role = factory.Faker("job")
+    biography = f"<p>{faker.paragraph()}</p>"
+    image = factory.SubFactory(CustomImageFactory)
+
+    @factory.post_generation
+    def related_teams(self, create, extracted, **kwargs):
+        if not create:
+            return
+        if not extracted:
+            self.related_teams.add(TeamFactory())
+        if extracted:
+            if isinstance(extracted, str):
+                self.related_teams.add(TeamFactory(name=extracted))
+            elif isinstance(extracted, Team):
+                self.related_teams.add(extracted)
+            else:
+                raise ValueError(
+                    "`related_teams` value must either be a string or a `Team` instance."
+                )
+
+    class Meta:
+        model = PersonPage

--- a/tbx/people/tests/test_author.py
+++ b/tbx/people/tests/test_author.py
@@ -1,0 +1,122 @@
+from django.test import TestCase
+
+from tbx.core.factories import HomePageFactory
+from tbx.images.factories import CustomImageFactory
+from tbx.people.models import Author, PersonIndexPage, PersonPage
+from tbx.taxonomy.factories import TeamFactory
+from wagtail.models import Site
+
+
+class TestAuthor(TestCase):
+    def setUp(self):
+        super().setUp()
+
+        site = Site.objects.get(is_default_site=True)
+        root = site.root_page.specific
+        home = HomePageFactory(parent=root)
+
+        site.root_page = home
+        site.save()
+
+        self.personindex = PersonIndexPage(
+            title="Team",
+            strapline="This is us, the people that make Torchbox",
+        )
+        home.add_child(instance=self.personindex)
+        self.personindex.save()
+
+    def test_author_created_when_personpage_published(self):
+        self.assertEqual(Author.objects.count(), 0)
+
+        person = PersonPage(
+            title="Juliet Jacques",
+            role="Tinkerer",
+            biography="<p>Meet JJ, the tinkerer extraordinaire, turning junk into genius with a wink and a wrench!</p>",
+            image=CustomImageFactory(),
+        )
+        self.personindex.add_child(instance=person)
+        person.save()
+        person.related_teams.add(TeamFactory(name="Engineering"))
+        revision = person.save_revision()
+        # Publish the page to trigger the page_published signal
+        revision.publish()
+
+        self.assertEqual(Author.objects.count(), 1)
+        author = Author.objects.first()
+        self.assertEqual(author.person_page, person)
+        self.assertEqual(author.name, person.title)
+        self.assertEqual(author.role, person.role)
+        self.assertEqual(author.image, person.image)
+
+    def test_author_updated_when_personpage_updated(self):
+        person = PersonPage(
+            title="Koldo Knightley",
+            role="Culinary Connoisseur",
+            biography="<p>With a spatula in hand and a sprinkle of spice, KK orchestrates culinary masterpieces that tantalize taste buds and delight diners.</p>",
+            image=CustomImageFactory(),
+        )
+        self.personindex.add_child(instance=person)
+        person.save()
+        person.related_teams.add(TeamFactory(name="Food and Beverage"))
+        person.save_revision().publish()
+
+        author = Author.objects.get(person_page=person)
+
+        # Check that the author's name is the person page's title
+        self.assertEqual(author.name, "Koldo Knightley")
+
+        # Now let's update the person page's title and publish it again
+        person.title = "Koldo “KK” Knightley"
+        person.save_revision().publish()
+
+        # The author's name should now be updated to reflect the new title
+        author.refresh_from_db()
+        self.assertEqual(author.name, "Koldo “KK” Knightley")
+
+    def test_author_remains_when_personpage_unpublished(self):
+        person = PersonPage(
+            title="Greta Goodman",
+            role="Gadget Guru",
+            biography="<p>Greta transforms futuristic ideas into reality with flair and finesse.</p>",
+            image=CustomImageFactory(),
+        )
+        self.personindex.add_child(instance=person)
+        person.save()
+        person.related_teams.add(TeamFactory(name="Gadgetry"))
+        person.save_revision().publish()
+
+        self.assertEqual(Author.objects.count(), 1)
+
+        person.unpublish()
+
+        # The Author should still exist
+        self.assertEqual(Author.objects.count(), 1)
+        author = Author.objects.first()
+        self.assertEqual(author.person_page, person)
+        self.assertEqual(author.name, person.title)
+        self.assertEqual(author.role, person.role)
+        self.assertEqual(author.image, person.image)
+
+    def test_author_remains_when_personpage_deleted(self):
+        person = PersonPage(
+            title="Giovanni Grant",
+            role="Fitness Trainer",
+            biography="<p>Giovanni empowers the team to achieve peak performance and unlock their full potential.</p>",
+            image=CustomImageFactory(),
+        )
+        self.personindex.add_child(instance=person)
+        person.save()
+        person.related_teams.add(TeamFactory(name="Fitness"))
+        person.save_revision().publish()
+
+        self.assertEqual(Author.objects.count(), 1)
+
+        person.delete()
+
+        # The Author should still exist
+        self.assertEqual(Author.objects.count(), 1)
+        author = Author.objects.first()
+        self.assertIsNone(author.person_page)
+        self.assertEqual(author.name, person.title)
+        self.assertEqual(author.role, person.role)
+        self.assertEqual(author.image, person.image)

--- a/tbx/people/tests/test_author.py
+++ b/tbx/people/tests/test_author.py
@@ -4,7 +4,7 @@ from tbx.core.factories import HomePageFactory
 from tbx.images.factories import CustomImageFactory
 from tbx.people.models import Author, PersonIndexPage, PersonPage
 from tbx.taxonomy.factories import TeamFactory
-from wagtail.models import Site
+from wagtail.models import Page, Site
 
 
 class TestAuthor(TestCase):
@@ -12,8 +12,8 @@ class TestAuthor(TestCase):
         super().setUp()
 
         site = Site.objects.get(is_default_site=True)
-        root = site.root_page.specific
-        home = HomePageFactory(parent=root)
+        root = Page.objects.get(depth=1)
+        home = HomePageFactory(title="Torchbox", parent=root)
 
         site.root_page = home
         site.save()

--- a/tbx/people/tests/test_factories.py
+++ b/tbx/people/tests/test_factories.py
@@ -2,7 +2,15 @@ from django.test import TestCase
 
 from tbx.core.factories import HomePageFactory, StandardPageFactory
 from tbx.core.models import StandardPage
-from tbx.people.factories import ContactFactory, ContactReasonsListFactory
+from tbx.people.factories import (
+    AuthorFactory,
+    ContactFactory,
+    ContactReasonsListFactory,
+    PersonIndexPageFactory,
+    PersonPageFactory,
+)
+from tbx.taxonomy.factories import TeamFactory
+from tbx.taxonomy.models import Team
 
 
 class ContactFactoryTestCase(TestCase):
@@ -117,3 +125,44 @@ class ContactReasonsListFactoryTestCase(TestCase):
         self.assertIsNotNone(contact_reasons_list.name)
         self.assertIsNotNone(contact_reasons_list.heading)
         self.assertEqual(contact_reasons_list.reasons.count(), 4)
+
+
+class AuthorFactoryTestCase(TestCase):
+    def test_author_factory(self):
+        author = AuthorFactory()
+        self.assertIsNotNone(author.name)
+        self.assertIsNotNone(author.role)
+        self.assertIsNotNone(author.image)
+
+
+class PersonIndexPageFactoryTestCase(TestCase):
+    def test_person_index_page_factory(self):
+        person_index_page = PersonIndexPageFactory()
+        self.assertIsNotNone(person_index_page.title)
+        self.assertIsNotNone(person_index_page.strapline)
+
+
+class PersonPageFactoryTestCase(TestCase):
+    def test_person_page_factory(self):
+        person_page = PersonPageFactory()
+        self.assertIsNotNone(person_page.title)
+        self.assertIsNotNone(person_page.role)
+        self.assertIsNotNone(person_page.biography)
+        self.assertIsNotNone(person_page.image)
+        self.assertEqual(person_page.related_teams.count(), 1)
+
+    def test_person_page_factory_with_related_team(self):
+        self.assertEqual(Team.objects.count(), 0)
+
+        # related_teams as a string
+        jane = PersonPageFactory(title="Jane Doe", related_teams="Engineering")
+        self.assertEqual(jane.related_teams.count(), 1)
+        self.assertEqual(jane.related_teams.first().name, "Engineering")
+
+        # related_teams as a `Team` instance
+        team = TeamFactory(name="Digital Marketing")
+        john = PersonPageFactory(title="John Doe", related_teams=team)
+        self.assertEqual(john.related_teams.count(), 1)
+        self.assertEqual(john.related_teams.first().name, "Digital Marketing")
+
+        self.assertEqual(Team.objects.count(), 2)

--- a/tbx/project_styleguide/templates/patterns/molecules/author/author.html
+++ b/tbx/project_styleguide/templates/patterns/molecules/author/author.html
@@ -8,7 +8,7 @@
         {% if author_attribution %}
             <p class="author__attribution">{{ author_attribution }}</p>
         {% endif %}
-        {% if author.person_page %}
+        {% if author.person_page.live %}
             <p class="author__name">
                 <a class="author__link" href="{% pageurl author.person_page %}" aria-label="By {{ author.name }}. View {{ author.name }}'s team profile page">
                     {{ author.name }}


### PR DESCRIPTION
[Link to Ticket](https://torchbox.monday.com/boards/1192293412/pulses/1369626170)

### Description of Changes Made

This ticket adds a fix to the author display component used on `WorkPage`s, `HistoricalWorkPage`s and `BlogPage`s -- ensuring that the `author.person_page` not only exists but is also published.

Since the display of author information is dependent on the Author / PersonPage logic, I wrote some unit tests to help catch regressions in this logic in the future. 

### How to Test

1. Pick a blog page / work page / historical work page whose author links to the author's person page.
2. Edit that person page by unpublishing it
3. Go back to the page in 1, the author should still be displayed, but there shouldn't be any link to the author's person page, since it's no longer live.
4. Now, delete the person page
5. Repeat step 3

<!--
### Screenshots

<details>
  <summary>Expand to see more</summary>

</details>
-->

### MR Checklist

- [x] Add a description of your pull request and instructions for the reviewer to verify your work.
- [x] If your pull request is for a specific ticket, link to it in the description.
- [x] Stay on point and keep it small so the merge request can be easily reviewed.
- [x] Tests and linting passes.

#### Unit tests

- [x] Added
- [ ] Not required

#### Documentation

- [ ] Updated build docs
- [ ] Updated editor guidelines (https://docs.google.com/document/d/1PAWccdQ4tfaZsrEWmpDhvP3GH5RRmBOARFVp4b-kje8/edit?usp=sharing)
- [x] Not required

#### Browser testing

- [x] I have tested in the following browsers and environments (edit the list as required)
  - Latest version of Chrome on Ubuntu
  - Latest version of Firefox on Ubuntu

#### Data protection

- [x] Not relevant
- [ ] This adds new sources of PII and documents it and modifies Birdbath processors accordingly

#### Accessibility

- [ ] Automated WCAG 2.1 tests pass
- [ ] Manual WCAG 2.1 tests completed
- [ ] I have tested in a screen reader
- [ ] I have tested in high-contrast mode
- [ ] Any animations removed for prefers-reduced-motion
- [x] Not required

#### Sustainability

- [ ] Images are optimised and lazy-loading used where appropriate
- [ ] SVGs have been optimised
- [ ] Perfomance and transfer of data considered
- [ ] If JavaScript is needed alternatives have been considered
- [x] Not required

#### Pattern library

- [ ] The pattern library component for this template displays correctly, and does not break parent templates
- [ ] The styleguide is updated if relevant
- [x] Changes are not relevant the pattern library
