### PR TITLE
Fix GIF Renditions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,10 +63,6 @@ ENV BUILD_ENV=${BUILD_ENV}
 # server (Gunicorn). This is read by Dokku only. Heroku will ignore this.
 EXPOSE 8000
 
-RUN apt-get update --yes --quiet && apt-get install --yes --quiet --no-install-recommends \
-    libmagickwand-dev \
-    && apt-get autoremove && rm -rf /var/lib/apt/lists/*
-
 # Install poetry at the system level
 RUN pip install --no-cache poetry==${POETRY_VERSION}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,6 +63,10 @@ ENV BUILD_ENV=${BUILD_ENV}
 # server (Gunicorn). This is read by Dokku only. Heroku will ignore this.
 EXPOSE 8000
 
+RUN apt-get update --yes --quiet && apt-get install --yes --quiet --no-install-recommends \
+    libmagickwand-dev \
+    && apt-get autoremove && rm -rf /var/lib/apt/lists/*
+
 # Install poetry at the system level
 RUN pip install --no-cache poetry==${POETRY_VERSION}
 

--- a/tbx/images/models.py
+++ b/tbx/images/models.py
@@ -12,6 +12,10 @@ class CustomImage(AbstractImage):
     def credit_text(self):
         return self.credit
 
+    @property
+    def is_gif(self):
+        return self.filename.lower().endswith(".gif")
+
 
 class Rendition(AbstractRendition):
     image = models.ForeignKey(

--- a/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/image_block.html
+++ b/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/image_block.html
@@ -1,12 +1,16 @@
 {% load wagtailcore_tags wagtailimages_tags %}
 
 <div class="image grid__image">
-    {% if value.image_is_decorative %}
-        {% srcset_image value.image format-webp saturation-0.6 width-{400,900,1800} sizes="(max-width: 1022px) 90vw, (max-width: 1879px) 50vw, (min-width: 1880px) 910px" loading="lazy" alt="" %}
-    {% elif value.alt_text %}
-        {% srcset_image value.image format-webp saturation-0.6 width-{400,900,1800} sizes="(max-width: 1022px) 90vw, (max-width: 1879px) 50vw, (min-width: 1880px) 910px" loading="lazy" alt=value.alt_text %}
+    {% if value.image.is_gif %}
+        {% image value.image width-800 %}
     {% else %}
-        {% srcset_image value.image format-webp saturation-0.6 width-{400,900,1800} sizes="(max-width: 1022px) 90vw, (max-width: 1879px) 50vw, (min-width: 1880px) 910px" loading="lazy" %}
+        {% if value.image_is_decorative %}
+            {% srcset_image value.image format-webp saturation-0.6 width-{400,900,1800} sizes="(max-width: 1022px) 90vw, (max-width: 1879px) 50vw, (min-width: 1880px) 910px" loading="lazy" alt="" %}
+        {% elif value.alt_text %}
+            {% srcset_image value.image format-webp saturation-0.6 width-{400,900,1800} sizes="(max-width: 1022px) 90vw, (max-width: 1879px) 50vw, (min-width: 1880px) 910px" loading="lazy" alt=value.alt_text %}
+        {% else %}
+            {% srcset_image value.image format-webp saturation-0.6 width-{400,900,1800} sizes="(max-width: 1022px) 90vw, (max-width: 1879px) 50vw, (min-width: 1880px) 910px" loading="lazy" %}
+        {% endif %}
     {% endif %}
 
     {% if value.caption %}


### PR DESCRIPTION
[Link to Ticket](https://torchbox.monday.com/boards/1192293412/pulses/1405112378)

### Description of Changes Made

A [couple of pages](https://torchbox.monday.com/boards/1192293412/pulses/1405112378/posts/198294490) have been observed to be crashing the site. [Initial investigations](https://torchbox.monday.com/boards/1192293412/pulses/1405112378/posts/199382725) revealed high memory usage relating to creating renditions in webp format.

Based on additional investigation, as [documented on the ticket](https://torchbox.monday.com/boards/1192293412/pulses/1405112378/posts/199483401), and based on [this Sentry error](https://torchbox.sentry.io/issues/5047929620/?project=1221893) I concluded that part of the problem was due to use of animated GIFs on some pages.

The `format-webp` and `saturation-0.6` filters seem to be problematic for animated GIFs. The problem is made worse when the `srcset_image` template tag is used on animated GIFs, because we are attempting to generate multiple renditions on one animated GIF -- further bumping up memory usage ([Operations involving animated GIFs are already known to result in high memory usage](https://github.com/wagtail/wagtail/issues/3575)). Therefore, in the interim, I thought it would be good to handle animated GIFs differently (e7791c61). Ultimately, we should probably just avoid using animated GIFs altogether, and use videos instead. 

This fix will facilitate editing those pages with animated GIFs, while we decide on the next steps.

### How to Test

Probably best to `pull-production-data` and `fab pull-production-images`, then try accessing the following URLs on the `main` branch before switching to the `fix/gif-renditions/` branch. 

- <http://127.0.0.1:8000/work/islamic-relief-uk-ramadan-campaign/>
- <http://127.0.0.1:8000/work/nhs-website-seo-case-study/>

You should encounter the Sentry error I referenced earlier:

<details><summary>Error</summary>

```console
17:44:55 web.1      | [08/Mar/2024 17:44:55] "GET /work/islamic-relief-uk-ramadan-campaign/ HTTP/1.1" 500 432518
17:45:25 web.1      | [2024-03-08 17:45:25,607][1479][ERROR][django.request] Internal Server Error: /work/nhs-website-seo-case-study/
17:45:25 web.1      | Traceback (most recent call last):
17:45:25 web.1      |   File "/venv/lib/python3.11/site-packages/django/core/handlers/exception.py", line 55, in inner
17:45:25 web.1      |     response = get_response(request)
17:45:25 web.1      |                ^^^^^^^^^^^^^^^^^^^^^
17:45:25 web.1      |   File "/venv/lib/python3.11/site-packages/django/core/handlers/base.py", line 220, in _get_response
17:45:25 web.1      |     response = response.render()
17:45:25 web.1      |                ^^^^^^^^^^^^^^^^^
17:45:25 web.1      |   File "/venv/lib/python3.11/site-packages/django/template/response.py", line 114, in render
17:45:25 web.1      |     self.content = self.rendered_content
17:45:25 web.1      |                    ^^^^^^^^^^^^^^^^^^^^^
17:45:25 web.1      |   File "/venv/lib/python3.11/site-packages/django/template/response.py", line 92, in rendered_content
17:45:25 web.1      |     return template.render(context, self._request)
17:45:25 web.1      |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
17:45:25 web.1      |   File "/venv/lib/python3.11/site-packages/django/template/backends/django.py", line 61, in render
17:45:25 web.1      |     return self.template.render(context)
17:45:25 web.1      |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
17:45:25 web.1      |   File "/venv/lib/python3.11/site-packages/django/template/base.py", line 175, in render
17:45:25 web.1      |     return self._render(context)
17:45:25 web.1      |            ^^^^^^^^^^^^^^^^^^^^^
17:45:25 web.1      |   File "/venv/lib/python3.11/site-packages/django/test/utils.py", line 112, in instrumented_test_render
17:45:25 web.1      |     return self.nodelist.render(context)
17:45:25 web.1      |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
17:45:25 web.1      |   File "/venv/lib/python3.11/site-packages/django/template/base.py", line 1005, in render
17:45:25 web.1      |     return SafeString("".join([node.render_annotated(context) for node in self]))
17:45:25 web.1      |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
17:45:25 web.1      |   File "/venv/lib/python3.11/site-packages/django/template/base.py", line 1005, in <listcomp>
17:45:25 web.1      |     return SafeString("".join([node.render_annotated(context) for node in self]))
17:45:25 web.1      |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
17:45:25 web.1      |   File "/venv/lib/python3.11/site-packages/django/template/base.py", line 966, in render_annotated
17:45:25 web.1      |     return self.render(context)
17:45:25 web.1      |            ^^^^^^^^^^^^^^^^^^^^
17:45:25 web.1      |   File "/venv/lib/python3.11/site-packages/pattern_library/loader_tags.py", line 38, in render
17:45:25 web.1      |     return super().render(context)
17:45:25 web.1      |            ^^^^^^^^^^^^^^^^^^^^^^^
17:45:25 web.1      |   File "/venv/lib/python3.11/site-packages/django/template/loader_tags.py", line 157, in render
17:45:25 web.1      |     return compiled_parent._render(context)
17:45:25 web.1      |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
17:45:25 web.1      |   File "/venv/lib/python3.11/site-packages/django/test/utils.py", line 112, in instrumented_test_render
17:45:25 web.1      |     return self.nodelist.render(context)
17:45:25 web.1      |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
17:45:25 web.1      |   File "/venv/lib/python3.11/site-packages/django/template/base.py", line 1005, in render
17:45:25 web.1      |     return SafeString("".join([node.render_annotated(context) for node in self]))
17:45:25 web.1      |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
17:45:25 web.1      |   File "/venv/lib/python3.11/site-packages/django/template/base.py", line 1005, in <listcomp>
17:45:25 web.1      |     return SafeString("".join([node.render_annotated(context) for node in self]))
17:45:25 web.1      |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
17:45:25 web.1      |   File "/venv/lib/python3.11/site-packages/django/template/base.py", line 966, in render_annotated
17:45:25 web.1      |     return self.render(context)
17:45:25 web.1      |            ^^^^^^^^^^^^^^^^^^^^
17:45:25 web.1      |   File "/venv/lib/python3.11/site-packages/pattern_library/loader_tags.py", line 38, in render
17:45:25 web.1      |     return super().render(context)
17:45:25 web.1      |            ^^^^^^^^^^^^^^^^^^^^^^^
17:45:25 web.1      |   File "/venv/lib/python3.11/site-packages/django/template/loader_tags.py", line 157, in render
17:45:25 web.1      |     return compiled_parent._render(context)
17:45:25 web.1      |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
17:45:25 web.1      |   File "/venv/lib/python3.11/site-packages/django/test/utils.py", line 112, in instrumented_test_render
17:45:25 web.1      |     return self.nodelist.render(context)
17:45:25 web.1      |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
17:45:25 web.1      |   File "/venv/lib/python3.11/site-packages/django/template/base.py", line 1005, in render
17:45:25 web.1      |     return SafeString("".join([node.render_annotated(context) for node in self]))
17:45:25 web.1      |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
17:45:25 web.1      |   File "/venv/lib/python3.11/site-packages/django/template/base.py", line 1005, in <listcomp>
17:45:25 web.1      |     return SafeString("".join([node.render_annotated(context) for node in self]))
17:45:25 web.1      |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
17:45:25 web.1      |   File "/venv/lib/python3.11/site-packages/django/template/base.py", line 966, in render_annotated
17:45:25 web.1      |     return self.render(context)
17:45:25 web.1      |            ^^^^^^^^^^^^^^^^^^^^
17:45:25 web.1      |   File "/venv/lib/python3.11/site-packages/pattern_library/loader_tags.py", line 38, in render
17:45:25 web.1      |     return super().render(context)
17:45:25 web.1      |            ^^^^^^^^^^^^^^^^^^^^^^^
17:45:25 web.1      |   File "/venv/lib/python3.11/site-packages/django/template/loader_tags.py", line 157, in render
17:45:25 web.1      |     return compiled_parent._render(context)
17:45:25 web.1      |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
17:45:25 web.1      |   File "/venv/lib/python3.11/site-packages/django/test/utils.py", line 112, in instrumented_test_render
17:45:25 web.1      |     return self.nodelist.render(context)
17:45:25 web.1      |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
17:45:25 web.1      |   File "/venv/lib/python3.11/site-packages/django/template/base.py", line 1005, in render
17:45:25 web.1      |     return SafeString("".join([node.render_annotated(context) for node in self]))
17:45:25 web.1      |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
17:45:25 web.1      |   File "/venv/lib/python3.11/site-packages/django/template/base.py", line 1005, in <listcomp>
17:45:25 web.1      |     return SafeString("".join([node.render_annotated(context) for node in self]))
17:45:25 web.1      |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
17:45:25 web.1      |   File "/venv/lib/python3.11/site-packages/django/template/base.py", line 966, in render_annotated
17:45:25 web.1      |     return self.render(context)
17:45:25 web.1      |            ^^^^^^^^^^^^^^^^^^^^
17:45:25 web.1      |   File "/venv/lib/python3.11/site-packages/django/template/loader_tags.py", line 63, in render
17:45:25 web.1      |     result = block.nodelist.render(context)
17:45:25 web.1      |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
17:45:25 web.1      |   File "/venv/lib/python3.11/site-packages/django/template/base.py", line 1005, in render
17:45:25 web.1      |     return SafeString("".join([node.render_annotated(context) for node in self]))
17:45:25 web.1      |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
17:45:25 web.1      |   File "/venv/lib/python3.11/site-packages/django/template/base.py", line 1005, in <listcomp>
17:45:25 web.1      |     return SafeString("".join([node.render_annotated(context) for node in self]))
17:45:25 web.1      |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
17:45:25 web.1      |   File "/venv/lib/python3.11/site-packages/django/template/base.py", line 966, in render_annotated
17:45:25 web.1      |     return self.render(context)
17:45:25 web.1      |            ^^^^^^^^^^^^^^^^^^^^
17:45:25 web.1      |   File "/venv/lib/python3.11/site-packages/django/template/loader_tags.py", line 63, in render
17:45:25 web.1      |     result = block.nodelist.render(context)
17:45:25 web.1      |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
17:45:25 web.1      |   File "/venv/lib/python3.11/site-packages/django/template/base.py", line 1005, in render
17:45:25 web.1      |     return SafeString("".join([node.render_annotated(context) for node in self]))
17:45:25 web.1      |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
17:45:25 web.1      |   File "/venv/lib/python3.11/site-packages/django/template/base.py", line 1005, in <listcomp>
17:45:25 web.1      |     return SafeString("".join([node.render_annotated(context) for node in self]))
17:45:25 web.1      |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
17:45:25 web.1      |   File "/venv/lib/python3.11/site-packages/django/template/base.py", line 966, in render_annotated
17:45:25 web.1      |     return self.render(context)
17:45:25 web.1      |            ^^^^^^^^^^^^^^^^^^^^
17:45:25 web.1      |   File "/venv/lib/python3.11/site-packages/django/template/defaulttags.py", line 238, in render
17:45:25 web.1      |     nodelist.append(node.render_annotated(context))
17:45:25 web.1      |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
17:45:25 web.1      |   File "/venv/lib/python3.11/site-packages/django/template/base.py", line 966, in render_annotated
17:45:25 web.1      |     return self.render(context)
17:45:25 web.1      |            ^^^^^^^^^^^^^^^^^^^^
17:45:25 web.1      |   File "/venv/lib/python3.11/site-packages/django/template/defaulttags.py", line 321, in render
17:45:25 web.1      |     return nodelist.render(context)
17:45:25 web.1      |            ^^^^^^^^^^^^^^^^^^^^^^^^
17:45:25 web.1      |   File "/venv/lib/python3.11/site-packages/django/template/base.py", line 1005, in render
17:45:25 web.1      |     return SafeString("".join([node.render_annotated(context) for node in self]))
17:45:25 web.1      |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
17:45:25 web.1      |   File "/venv/lib/python3.11/site-packages/django/template/base.py", line 1005, in <listcomp>
17:45:25 web.1      |     return SafeString("".join([node.render_annotated(context) for node in self]))
17:45:25 web.1      |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
17:45:25 web.1      |   File "/venv/lib/python3.11/site-packages/django/template/base.py", line 966, in render_annotated
17:45:25 web.1      |     return self.render(context)
17:45:25 web.1      |            ^^^^^^^^^^^^^^^^^^^^
17:45:25 web.1      |   File "/venv/lib/python3.11/site-packages/pattern_library/monkey_utils.py", line 92, in node_render
17:45:25 web.1      |     return original_node_render(context)
17:45:25 web.1      |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
17:45:25 web.1      |   File "/venv/lib/python3.11/site-packages/wagtail/templatetags/wagtailcore_tags.py", line 150, in render
17:45:25 web.1      |     output = value.render_as_block(context=new_context)
17:45:25 web.1      |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
17:45:25 web.1      |   File "/venv/lib/python3.11/site-packages/wagtail/blocks/base.py", line 470, in render_as_block
17:45:25 web.1      |     return self.block.render(self.value, context=context)
17:45:25 web.1      |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
17:45:25 web.1      |   File "/venv/lib/python3.11/site-packages/wagtail/blocks/base.py", line 247, in render
17:45:25 web.1      |     return mark_safe(render_to_string(template, new_context))
17:45:25 web.1      |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
17:45:25 web.1      |   File "/venv/lib/python3.11/site-packages/django/template/loader.py", line 62, in render_to_string
17:45:25 web.1      |     return template.render(context, request)
17:45:25 web.1      |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
17:45:25 web.1      |   File "/venv/lib/python3.11/site-packages/django/template/backends/django.py", line 61, in render
17:45:25 web.1      |     return self.template.render(context)
17:45:25 web.1      |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
17:45:25 web.1      |   File "/venv/lib/python3.11/site-packages/django/template/base.py", line 175, in render
17:45:25 web.1      |     return self._render(context)
17:45:25 web.1      |            ^^^^^^^^^^^^^^^^^^^^^
17:45:25 web.1      |   File "/venv/lib/python3.11/site-packages/django/test/utils.py", line 112, in instrumented_test_render
17:45:25 web.1      |     return self.nodelist.render(context)
17:45:25 web.1      |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
17:45:25 web.1      |   File "/venv/lib/python3.11/site-packages/django/template/base.py", line 1005, in render
17:45:25 web.1      |     return SafeString("".join([node.render_annotated(context) for node in self]))
17:45:25 web.1      |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
17:45:25 web.1      |   File "/venv/lib/python3.11/site-packages/django/template/base.py", line 1005, in <listcomp>
17:45:25 web.1      |     return SafeString("".join([node.render_annotated(context) for node in self]))
17:45:25 web.1      |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
17:45:25 web.1      |   File "/venv/lib/python3.11/site-packages/django/template/base.py", line 966, in render_annotated
17:45:25 web.1      |     return self.render(context)
17:45:25 web.1      |            ^^^^^^^^^^^^^^^^^^^^
17:45:25 web.1      |   File "/venv/lib/python3.11/site-packages/django/template/defaulttags.py", line 321, in render
17:45:25 web.1      |     return nodelist.render(context)
17:45:25 web.1      |            ^^^^^^^^^^^^^^^^^^^^^^^^
17:45:25 web.1      |   File "/venv/lib/python3.11/site-packages/django/template/base.py", line 1005, in render
17:45:25 web.1      |     return SafeString("".join([node.render_annotated(context) for node in self]))
17:45:25 web.1      |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
17:45:25 web.1      |   File "/venv/lib/python3.11/site-packages/django/template/base.py", line 1005, in <listcomp>
17:45:25 web.1      |     return SafeString("".join([node.render_annotated(context) for node in self]))
17:45:25 web.1      |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
17:45:25 web.1      |   File "/venv/lib/python3.11/site-packages/django/template/base.py", line 966, in render_annotated
17:45:25 web.1      |     return self.render(context)
17:45:25 web.1      |            ^^^^^^^^^^^^^^^^^^^^
17:45:25 web.1      |   File "/venv/lib/python3.11/site-packages/pattern_library/monkey_utils.py", line 92, in node_render
17:45:25 web.1      |     return original_node_render(context)
17:45:25 web.1      |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
17:45:25 web.1      |   File "/venv/lib/python3.11/site-packages/wagtail/images/templatetags/wagtailimages_tags.py", line 181, in render
17:45:25 web.1      |     renditions = get_renditions_or_not_found(image, specs)
17:45:25 web.1      |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
17:45:25 web.1      |   File "/venv/lib/python3.11/site-packages/wagtail/images/shortcuts.py", line 35, in get_renditions_or_not_found
17:45:25 web.1      |     return image.get_renditions(*specs)
17:45:25 web.1      |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
17:45:25 web.1      |   File "/venv/lib/python3.11/site-packages/wagtail/images/models.py", line 545, in get_renditions
17:45:25 web.1      |     return {filter.spec: renditions[filter] for filter in filters}
17:45:25 web.1      |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
17:45:25 web.1      |   File "/venv/lib/python3.11/site-packages/wagtail/images/models.py", line 545, in <dictcomp>
17:45:25 web.1      |     return {filter.spec: renditions[filter] for filter in filters}
17:45:25 web.1      |                          ~~~~~~~~~~^^^^^^^^
17:45:25 web.1      | KeyError: <wagtail.images.models.Filter object at 0x71c4b9d821d0>

```

</details> 

Now, if you checkout the  `fix/gif-renditions/` branch, run `fab build` and access the same URLs. The pages should load. Initial load will take a while, because of the creation of the rendition for the animated GIF. However, after the first load, subsequent page loads are much faster.

<!--
### Screenshots

<details>
  <summary>Expand to see more</summary>

</details>
-->

### MR Checklist

- [x] Add a description of your pull request and instructions for the reviewer to verify your work.
- [x] If your pull request is for a specific ticket, link to it in the description.
- [x] Stay on point and keep it small so the merge request can be easily reviewed.
- [x] Tests and linting passes.

#### Unit tests

- [ ] Added
- [x] Not required

#### Documentation

- [ ] Updated build docs
- [ ] Updated editor guidelines (https://docs.google.com/document/d/1PAWccdQ4tfaZsrEWmpDhvP3GH5RRmBOARFVp4b-kje8/edit?usp=sharing)
- [x] Not required

#### Browser testing

- [x] I have tested in the following browsers and environments (edit the list as required)
  - Latest version of Chrome on Ubuntu
  - Latest version of Firefox on Ubuntu

#### Data protection

- [x] Not relevant
- [ ] This adds new sources of PII and documents it and modifies Birdbath processors accordingly

#### Accessibility

- [ ] Automated WCAG 2.1 tests pass
- [ ] Manual WCAG 2.1 tests completed
- [ ] I have tested in a screen reader
- [ ] I have tested in high-contrast mode
- [ ] Any animations removed for prefers-reduced-motion
- [x] Not required

#### Sustainability

- [ ] Images are optimised and lazy-loading used where appropriate
- [ ] SVGs have been optimised
- [x] Perfomance and transfer of data considered
- [ ] If JavaScript is needed alternatives have been considered
- [ ] Not required

#### Pattern library

- [ ] The pattern library component for this template displays correctly, and does not break parent templates
- [ ] The styleguide is updated if relevant
- [x] Changes are not relevant the pattern library
