### PR TITLE
Amend work page markup so we can use heading level 2s on the page

### DIFF
--- a/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/work_section_block.html
+++ b/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/work_section_block.html
@@ -2,13 +2,13 @@
 
 
 {# see _grid.scss for how the titles and content streamfields are placed on grid #}
-<h2 class="grid__work-title work-sections__title">
+<p class="grid__work-title work-sections__title">
     <span class="work-sections__rings">
         {% include "patterns/atoms/icons/icon.html" with name="ring-one" classname="icon--stroke work-sections__ring work-sections__ring--one" %}
         {% include "patterns/atoms/icons/icon.html" with name="ring-two" classname="icon--stroke work-sections__ring work-sections__ring--two" %}
     </span>
     {{ value.title }}
-</h2>
+</p>
 
 
 {# A nested set of streamfield blocks for each title #}


### PR DESCRIPTION
[Link to Ticket](https://torchbox.monday.com/boards/1192293412/pulses/1417405198)

### Description of Changes Made

After some back and forth we settled on changing the markup of the text elemetns on the left of the page from headings to paragraphs, so that heading 2s can be used on these pages.

### How to Test

View a new work page in your local build, e.g. http://localhost:8000/work/a-world-record-for-dec-ukraine-appeal/ (after pulling production data) - check that the left-hand text elements are paragraph tags.

### Screenshots

<details>
  <summary>Expand to see more</summary>

</details>

### MR Checklist

- [x] Add a description of your pull request and instructions for the reviewer to verify your work.
- [x] If your pull request is for a specific ticket, link to it in the description.
- [x] Stay on point and keep it small so the merge request can be easily reviewed.
- [x] Tests and linting passes.

#### Unit tests

- [ ] Added
- [x] Not required

#### Documentation

- [ ] Updated build docs
- [x] Updated editor guidelines (https://docs.google.com/document/d/1PAWccdQ4tfaZsrEWmpDhvP3GH5RRmBOARFVp4b-kje8/edit?usp=sharing)
- [ ] Not required

#### Browser testing

- [x] I have tested in the following browsers and environments (edit the list as required)
  - Latest version of Chrome on mac
- [ ] Not required

#### Data protection

- [x] Not relevant
- [ ] This adds new sources of PII and documents it and modifies Birdbath processors accordingly

#### Accessibility

- [x] Automated WCAG 2.1 tests pass
- [ ] Manual WCAG 2.1 tests completed
- [x] I have tested in a screen reader
- [ ] I have tested in high-contrast mode
- [ ] Any animations removed for prefers-reduced-motion
- [ ] Not required

#### Sustainability

- [ ] Images are optimised and lazy-loading used where appropriate
- [ ] SVGs have been optimised
- [ ] Perfomance and transfer of data considered
- [ ] If JavaScript is needed alternatives have been considered
- [x] Not required

#### Pattern library

- [ ] The pattern library component for this template displays correctly, and does not break parent templates
- [ ] The styleguide is updated if relevant
- [x] Changes are not relevant the pattern library
