### PR TITLE
Do not display unused taxonomies on Work and Blog listings

### DIFF
--- a/tbx/blog/models.py
+++ b/tbx/blog/models.py
@@ -28,6 +28,12 @@ class BlogIndexPage(ColourThemeMixin, ContactMixin, SocialFields, Page):
 
     subpage_types = ["BlogPage"]
 
+    @cached_property
+    def taxonomy_slugs(self):
+        services = Service.objects.values_list("slug", flat=True)
+        sectors = Sector.objects.values_list("slug", flat=True)
+        return services.union(sectors)
+
     @property
     def blog_posts(self):
         # Get list of blog pages that are descendants of this page
@@ -48,7 +54,7 @@ class BlogIndexPage(ColourThemeMixin, ContactMixin, SocialFields, Page):
         slug_filter = request.GET.get("filter")
         extra_url_params = {}
 
-        if slug_filter:
+        if slug_filter and slug_filter in self.taxonomy_slugs:
             blog_posts = blog_posts.filter(
                 Q(related_sectors__slug=slug_filter)
                 | Q(related_services__slug=slug_filter)

--- a/tbx/blog/models.py
+++ b/tbx/blog/models.py
@@ -82,8 +82,14 @@ class BlogIndexPage(ColourThemeMixin, ContactMixin, SocialFields, Page):
         except EmptyPage:
             blog_posts = paginator.page(paginator.num_pages)
 
-        related_sectors = Sector.objects.all()
-        related_services = Service.objects.all()
+        # Only show Sectors and Services that have been used
+        related_sectors = Sector.objects.filter(
+            pk__in=models.Subquery(self.blog_posts.values("related_sectors"))
+        )
+
+        related_services = Service.objects.filter(
+            pk__in=models.Subquery(self.blog_posts.values("related_services"))
+        )
         tags = chain(related_services, related_sectors)
 
         context.update(

--- a/tbx/work/models.py
+++ b/tbx/work/models.py
@@ -409,8 +409,18 @@ class WorkIndexPage(ColourThemeMixin, ContactMixin, SocialFields, Page):
         except EmptyPage:
             works = paginator.page(paginator.num_pages)
 
-        related_sectors = Sector.objects.all()
-        related_services = Service.objects.all()
+        # Only show Sectors and Services that have been used
+        related_sectors = Sector.objects.filter(
+            pk__in=models.Subquery(self.works.values("workpage__related_sectors"))
+        )
+        related_services = Service.objects.filter(
+            Q(pk__in=models.Subquery(self.works.values("workpage__related_services")))
+            | Q(
+                pk__in=models.Subquery(
+                    self.works.values("historicalworkpage__related_services")
+                )
+            )
+        )
 
         # Used for the purposes of defining the filterable tags
         tags = chain(related_services, related_sectors)


### PR DESCRIPTION
[Link to Ticket](https://torchbox.monday.com/boards/1192293412/pulses/1414738166)

### Description of Changes Made

This PR makes changes to the Work and Blog listings so that only Service and Sector taxonomies that are associated with the child pages are available on the listing for filtering.

By doing this, we avoid returning zero results when one tries to apply a filter that is not associated with any Page, as documented on the [ticket](https://torchbox.monday.com/boards/1192293412/pulses/1414738166). 

### How to Test

1. Pull latest staging data if you haven't already done so
2. Add at least 1 service taxonomy at http://127.0.0.1:8000/admin/taxonomy/service/
3. Add at least 1 sector taxonomy at http://127.0.0.1:8000/admin/taxonomy/sector/
4. View the work listing page at http://127.0.0.1:8000/work/, the taxonomies you added above shouldn't be shown.
5. Similarly, when you view the blog listing at http://127.0.0.1:8000/blog/, you shouldn't see any of the taxonomies you added.
6. Now, you can edit any BlogPage by adding one of the new taxonomies you created earlier. When you view the blog listing at http://127.0.0.1:8000/blog/, you should see the new taxonomy displayed alongside the others.
7. Repeat step 6 for a WorkPage, and verify that when you view http://127.0.0.1:8000/work/, you see the taxonomy displayed.

<!--
### Screenshots

<details>
  <summary>Expand to see more</summary>

</details>
-->

### MR Checklist

- [x] Add a description of your pull request and instructions for the reviewer to verify your work.
- [x] If your pull request is for a specific ticket, link to it in the description.
- [x] Stay on point and keep it small so the merge request can be easily reviewed.
- [x] Tests and linting passes.

#### Unit tests

- [ ] Added
- [x] Not required

#### Documentation

- [ ] Updated build docs
- [ ] Updated editor guidelines (https://docs.google.com/document/d/1PAWccdQ4tfaZsrEWmpDhvP3GH5RRmBOARFVp4b-kje8/edit?usp=sharing)
- [x] Not required

#### Browser testing

- [x] I have tested in the following browsers and environments (edit the list as required)
  - Latest version of Chrome on Linux
- [ ] Not required

#### Data protection

- [x] Not relevant
- [ ] This adds new sources of PII and documents it and modifies Birdbath processors accordingly

#### Accessibility

- [ ] Automated WCAG 2.1 tests pass
- [ ] Manual WCAG 2.1 tests completed
- [ ] I have tested in a screen reader
- [ ] I have tested in high-contrast mode
- [ ] Any animations removed for prefers-reduced-motion
- [x] Not required

#### Sustainability

- [ ] Images are optimised and lazy-loading used where appropriate
- [ ] SVGs have been optimised
- [x] Perfomance and transfer of data considered
- [ ] If JavaScript is needed alternatives have been considered
- [ ] Not required

#### Pattern library

- [ ] The pattern library component for this template displays correctly, and does not break parent templates
- [ ] The styleguide is updated if relevant
- [x] Changes are not relevant the pattern library
