### PR TITLE
Feature/related pages ordering

### DIFF
--- a/tbx/blog/models.py
+++ b/tbx/blog/models.py
@@ -194,7 +194,7 @@ class BlogPage(ColourThemeMixin, ContactMixin, SocialFields, Page):
             .prefetch_related("related_sectors", "related_services")
             .defer_streamfields()
             .distinct()
-            .order_by("-first_published_at")
+            .order_by("-date")
             .exclude(pk=self.pk)[:3]
         ]
 

--- a/tbx/core/templatetags/torchbox_tags.py
+++ b/tbx/core/templatetags/torchbox_tags.py
@@ -3,9 +3,6 @@ from django.conf import settings
 
 from tbx.blog.models import BlogPage
 from tbx.core.models import MainMenu
-from tbx.core.utils import roundrobin
-from tbx.people.models import PersonPage
-from tbx.work.models import HistoricalWorkPage
 
 register = template.Library()
 
@@ -68,79 +65,6 @@ def content_type(value):
 @register.simple_tag
 def main_menu():
     return MainMenu.objects.first()
-
-
-# Person feed for home page
-@register.inclusion_tag(
-    "torchbox/tags/homepage_people_listing.html", takes_context=True
-)
-def homepage_people_listing(context, count=3):
-    people = PersonPage.objects.filter(live=True).order_by("?")[:count]
-    return {
-        "people": people,
-        # required by the pageurl tag that we want to use within this template
-        "request": context["request"],
-    }
-
-
-# Blog feed for home page
-@register.inclusion_tag("torchbox/tags/homepage_blog_listing.html", takes_context=True)
-def homepage_blog_listing(context, count=6):
-    blog_posts = BlogPage.objects.live().in_menu().order_by("-date")[:count]
-    return {
-        "blog_posts": blog_posts,
-        # required by the pageurl tag that we want to use within this template
-        "request": context["request"],
-    }
-
-
-# Work feed for home page
-@register.inclusion_tag("torchbox/tags/homepage_work_listing.html", takes_context=True)
-def homepage_work_listing(context, count=3):
-    work = HistoricalWorkPage.objects.filter(live=True)[:count]
-    return {
-        "work": work,
-        # required by the pageurl tag that we want to use within this template
-        "request": context["request"],
-    }
-
-
-# blog posts by team member
-@register.inclusion_tag("torchbox/tags/person_blog_listing.html", takes_context=True)
-def person_blog_post_listing(context, calling_page=None):
-    posts = (
-        BlogPage.objects.filter(authors__author__person_page_id=calling_page.id)
-        .live()
-        .order_by("-date")
-    )
-    return {
-        "posts": posts,
-        "calling_page": calling_page,
-        # required by the pageurl tag that we want to use within this template
-        "request": context["request"],
-    }
-
-
-@register.inclusion_tag("torchbox/tags/work_and_blog_listing.html", takes_context=True)
-def work_and_blog_listing(context, count=10):
-    """
-    An interleaved list of work and blog items.
-    """
-    blog_posts = BlogPage.objects.filter(live=True)
-    works = HistoricalWorkPage.objects.filter(live=True)
-
-    # If (remaining) count is odd, blog_count = work_count + 1
-    blog_count = (count + 1) / 2
-    work_count = count / 2
-
-    blog_posts = blog_posts.order_by("-date")[:blog_count]
-    works = works.order_by("-pk")[:work_count]
-
-    return {
-        "items": list(roundrobin(blog_posts, works)),
-        # required by the pageurl tag that we want to use within this template
-        "request": context["request"],
-    }
 
 
 # Format times e.g. on event page

--- a/tbx/work/models.py
+++ b/tbx/work/models.py
@@ -114,7 +114,7 @@ class HistoricalWorkPage(ColourThemeMixin, ContactMixin, SocialFields, Page):
             )
             .live()
             .distinct()
-            .order_by("-date")
+            .order_by(F("date").desc(nulls_last=True))
             .exclude(pk=self.pk)[:4]
         )
         return works
@@ -300,7 +300,7 @@ class WorkPage(ColourThemeMixin, ContactMixin, SocialFields, Page):
             )
             .defer_streamfields()
             .distinct()
-            .order_by("-date")
+            .order_by(F("date").desc(nulls_last=True))
             .exclude(pk=self.pk)[:3]
         ]
 

--- a/tbx/work/models.py
+++ b/tbx/work/models.py
@@ -114,7 +114,7 @@ class HistoricalWorkPage(ColourThemeMixin, ContactMixin, SocialFields, Page):
             )
             .live()
             .distinct()
-            .order_by("-id")
+            .order_by("-date")
             .exclude(pk=self.pk)[:4]
         )
         return works
@@ -300,7 +300,7 @@ class WorkPage(ColourThemeMixin, ContactMixin, SocialFields, Page):
             )
             .defer_streamfields()
             .distinct()
-            .order_by("-id")
+            .order_by("-date")
             .exclude(pk=self.pk)[:3]
         ]
 


### PR DESCRIPTION
[Link to Ticket](https://torchbox.monday.com/boards/1192293412/pulses/1426630701)

### Description of Changes Made

This PR modifies the way related blog posts, historical work pages and work pages are ordered in the "related posts" section of blog pages, historical work pages and work pages, respectively.

The idea is to ensure that they are ordered by `date`,in descending order, rather than by published date or id. 

Since the `date` is optional for work and historical work pages, we ensure that pages without the `date` specified appear last in the QuerySet.

Additionally, I have removed some unused template inclusion tags in 51f0a07

### How to Test

- Pick any blog page with related posts, and make changes to one of its related posts' date. Check that the ordering of the related posts is updated accordingly
- Pick any work page with related posts, and make changes to one of its related posts' date. Check that the ordering of the related posts is updated accordingly
- Pick any historical work page with related posts, and make changes to one of its related posts' date. Check that the ordering of the related posts is updated accordingly

<!--
### Screenshots

<details>
  <summary>Expand to see more</summary>

</details>
-->

### MR Checklist

- [x] Add a description of your pull request and instructions for the reviewer to verify your work.
- [x] If your pull request is for a specific ticket, link to it in the description.
- [x] Stay on point and keep it small so the merge request can be easily reviewed.
- [x] Tests and linting passes.

#### Unit tests

- [ ] Added
- [x] Not required

#### Documentation

- [ ] Updated build docs
- [ ] Updated editor guidelines (https://docs.google.com/document/d/1PAWccdQ4tfaZsrEWmpDhvP3GH5RRmBOARFVp4b-kje8/edit?usp=sharing)
- [x] Not required

#### Browser testing

- [ ] I have tested in the following browsers and environments (edit the list as required)
  - Latest version of Chrome on mac
  - Latest version of Firefox on mac
  - Latest version of Safari on mac
  - Safari on last two versions of iOS
  - Chrome on last two versions of Android
- [x] Not required

#### Data protection

- [x] Not relevant
- [ ] This adds new sources of PII and documents it and modifies Birdbath processors accordingly

#### Accessibility

- [ ] Automated WCAG 2.1 tests pass
- [ ] HTML validation passes
- [ ] Manual WCAG 2.1 tests completed
- [ ] I have tested in a screen reader
- [ ] I have tested in high-contrast mode
- [ ] Any animations removed for prefers-reduced-motion
- [x] Not required

#### Sustainability

- [ ] Images are optimised and lazy-loading used where appropriate
- [ ] SVGs have been optimised
- [ ] Perfomance and transfer of data considered
- [ ] If JavaScript is needed alternatives have been considered
- [x] Not required

#### Pattern library

- [ ] The pattern library component for this template displays correctly, and does not break parent templates
- [ ] The styleguide is updated if relevant
- [x] Changes are not relevant the pattern library
