### PR TITLE
[4287] Fix scroll remains disabled when closing navigation menu

### DIFF
--- a/tbx/static_src/javascript/components/desktop-close-menus.js
+++ b/tbx/static_src/javascript/components/desktop-close-menus.js
@@ -29,6 +29,7 @@ class DesktopCloseMenus {
             this.desktopSubMenus.forEach((item) => {
                 item.closest('[data-has-subnav]').classList.remove('active');
                 item.setAttribute('aria-expanded', 'false');
+                this.body.classList.remove('no-scroll');
             });
         }
     }


### PR DESCRIPTION
[Link to Ticket](https://torchbox.monday.com/boards/1192293412/pulses/1458814287)

### Description of Changes Made

Adds an update to remove the 'no-scroll' class when user closes the navigation by clicking outside the navigation element.

### How to Test

- Open navigation dropdown
- Close navigation by clicking anywhere outside of the nav
- See that the page will allow you to scroll

### MR Checklist

- [x] Add a description of your pull request and instructions for the reviewer to verify your work.
- [x] If your pull request is for a specific ticket, link to it in the description.
- [x] Stay on point and keep it small so the merge request can be easily reviewed.
- [x] Tests and linting passes.

#### Unit tests

- [ ] Added
- [x] Not required

#### Documentation

- [ ] Updated build docs
- [ ] Updated editor guidelines (https://docs.google.com/document/d/1PAWccdQ4tfaZsrEWmpDhvP3GH5RRmBOARFVp4b-kje8/edit?usp=sharing)
- [x] Not required

#### Browser testing

- [ ] I have tested in the following browsers and environments (edit the list as required)
  - Latest version of Chrome on mac
  - Latest version of Firefox on mac
  - Latest version of Safari on mac
  - Safari on last two versions of iOS
  - Chrome on last two versions of Android
- [x] Not required

#### Data protection

- [x] Not relevant
- [ ] This adds new sources of PII and documents it and modifies Birdbath processors accordingly

#### Accessibility

- [ ] Automated WCAG 2.1 tests pass
- [ ] HTML validation passes
- [ ] Manual WCAG 2.1 tests completed
- [ ] I have tested in a screen reader
- [ ] I have tested in high-contrast mode
- [ ] Any animations removed for prefers-reduced-motion
- [x] Not required

#### Sustainability

- [ ] Images are optimised and lazy-loading used where appropriate
- [ ] SVGs have been optimised
- [ ] Perfomance and transfer of data considered
- [ ] If JavaScript is needed alternatives have been considered
- [x] Not required

#### Pattern library

- [ ] The pattern library component for this template displays correctly, and does not break parent templates
- [ ] The styleguide is updated if relevant
- [x] Changes are not relevant the pattern library
