### PR TITLE
Fix the avatar image so it never resizes

### DIFF
--- a/tbx/static_src/sass/components/_avatar.scss
+++ b/tbx/static_src/sass/components/_avatar.scss
@@ -4,6 +4,9 @@
     position: relative;
     width: $avatar-size-72;
     height: $avatar-size-72;
+    // Make sure avatars don't get squashed on small screens
+    flex-grow: 0;
+    flex-shrink: 0;
 
     @include media-query(medium) {
         width: $avatar-size-145;
@@ -70,11 +73,5 @@
     &__image {
         border-radius: 50%;
         width: 100%;
-    }
-
-    // Make sure avatars don't get squashed on small screens
-    .authors-wide &,
-    .author & {
-        flex-shrink: 0;
     }
 }


### PR DESCRIPTION
[Link to Ticket](https://torchbox.monday.com/boards/1192293412/pulses/1466766842)

### Description of Changes Made

### How to Test

pull production data and images
visit http://localhost:8000/about/diversity-and-inclusion/ at mobile - Iona's image should not get squashed.

### Screenshots

<details>
  <summary>Expand to see more</summary>

![Screenshot 2024-04-16 at 11 29 29](https://github.com/torchbox/torchbox.com/assets/771869/666b107d-4e14-410c-8f5f-f5aadcbd253e)

</details>

### MR Checklist

- [x] Add a description of your pull request and instructions for the reviewer to verify your work.
- [x] If your pull request is for a specific ticket, link to it in the description.
- [x] Stay on point and keep it small so the merge request can be easily reviewed.
- [x] Tests and linting passes.

#### Unit tests

- [ ] Added
- [x] Not required

#### Documentation

- [ ] Updated build docs
- [ ] Updated editor guidelines (https://docs.google.com/document/d/1PAWccdQ4tfaZsrEWmpDhvP3GH5RRmBOARFVp4b-kje8/edit?usp=sharing)
- [x] Not required

#### Browser testing

- [ ] I have tested in the following browsers and environments (edit the list as required)
  - Latest version of Chrome on mac
- [x] Not required

#### Data protection

- [x] Not relevant
- [ ] This adds new sources of PII and documents it and modifies Birdbath processors accordingly

#### Accessibility

- [ ] Automated WCAG 2.1 tests pass
- [ ] HTML validation passes
- [ ] Manual WCAG 2.1 tests completed
- [ ] I have tested in a screen reader
- [ ] I have tested in high-contrast mode
- [ ] Any animations removed for prefers-reduced-motion
- [x] Not required

#### Sustainability

- [ ] Images are optimised and lazy-loading used where appropriate
- [ ] SVGs have been optimised
- [ ] Perfomance and transfer of data considered
- [ ] If JavaScript is needed alternatives have been considered
- [x] Not required

#### Pattern library

- [ ] The pattern library component for this template displays correctly, and does not break parent templates
- [ ] The styleguide is updated if relevant
- [x] Changes are not relevant the pattern library
