### PR TITLE
Help text amendment

### DIFF
--- a/tbx/impact_reports/blocks.py
+++ b/tbx/impact_reports/blocks.py
@@ -10,14 +10,14 @@ from wagtail.images.blocks import ImageChooserBlock
 
 
 class ImpactReportHeadingBlock(StructBlock):
-    image = ImageChooserBlock(required=False)
-    short_heading = CharBlock(
-        required=False, help_text="Used for the Table of Contents"
-    )
-    heading = CharBlock(
+    image = ImageChooserBlock(
         required=False,
         help_text="Can be omitted for the first heading immediately after the main image",
     )
+    short_heading = CharBlock(
+        required=False, help_text="Used for the Table of Contents"
+    )
+    heading = CharBlock(required=False)
 
     class Meta:
         icon = "title"


### PR DESCRIPTION


[Link to Ticket update](https://torchbox.monday.com/boards/1192293412/pulses/1439824220/posts/235418712)

### Description of Changes Made

Add the help text to the image field rather than the heading field in the impact report heading block

### How to Test

### Screenshots

<details>
  <summary>Expand to see more</summary>

![Screenshot 2024-04-17 at 09 04 36](https://github.com/torchbox/torchbox.com/assets/771869/b59895da-23a9-4623-acce-8c963358c0b9)

</details>

### MR Checklist

- [x] Add a description of your pull request and instructions for the reviewer to verify your work.
- [x] If your pull request is for a specific ticket, link to it in the description.
- [x] Stay on point and keep it small so the merge request can be easily reviewed.
- [x] Tests and linting passes.

#### Unit tests

- [ ] Added
- [x] Not required

#### Documentation

- [ ] Updated build docs
- [ ] Updated editor guidelines (https://docs.google.com/document/d/1PAWccdQ4tfaZsrEWmpDhvP3GH5RRmBOARFVp4b-kje8/edit?usp=sharing)
- [x] Not required

#### Browser testing

- [x] I have tested in the following browsers and environments (edit the list as required)
  - Latest version of Chrome on mac
- [ ] Not required

#### Data protection

- [x] Not relevant
- [ ] This adds new sources of PII and documents it and modifies Birdbath processors accordingly

#### Accessibility

- [ ] Automated WCAG 2.1 tests pass
- [ ] HTML validation passes
- [ ] Manual WCAG 2.1 tests completed
- [ ] I have tested in a screen reader
- [ ] I have tested in high-contrast mode
- [ ] Any animations removed for prefers-reduced-motion
- [ ] Not required

#### Sustainability

- [ ] Images are optimised and lazy-loading used where appropriate
- [ ] SVGs have been optimised
- [ ] Perfomance and transfer of data considered
- [ ] If JavaScript is needed alternatives have been considered
- [x] Not required

#### Pattern library

- [ ] The pattern library component for this template displays correctly, and does not break parent templates
- [ ] The styleguide is updated if relevant
- [x] Changes are not relevant the pattern library
