### PR TITLE
Use motif headings for h2s on the service page, and indent the paragraph blocks

### DIFF
--- a/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/heading2_motif_block.html
+++ b/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/heading2_motif_block.html
@@ -1,0 +1,1 @@
+{% include "patterns/atoms/motif-heading/motif-heading.html" with heading=value heading_level=2 classes="motif-heading--two motif-heading--static grid__heading grid__heading--motif" %}

--- a/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/heading2_motif_block.yaml
+++ b/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/heading2_motif_block.yaml
@@ -1,0 +1,2 @@
+context:
+  value: Heading text

--- a/tbx/services/blocks.py
+++ b/tbx/services/blocks.py
@@ -73,7 +73,6 @@ class ServiceStoryBlock(StoryBlock):
     paragraph = blocks.RichTextBlock(
         icon="pilcrow",
         template="patterns/molecules/streamfield/blocks/paragraph_block.html",
-        features=['h3', 'h4', 'bold', 'italic', 'ul', 'ol', 'link', 'document-link'],
+        features=["h3", "h4", "bold", "italic", "ul", "ol", "link", "document-link"],
         group="Basics",
     )
-

--- a/tbx/services/blocks.py
+++ b/tbx/services/blocks.py
@@ -62,3 +62,18 @@ class ServiceStoryBlock(StoryBlock):
     tabbed_paragraph = TabbedParagraphBlock()
     event = EventBlock()
     values = ValuesBlock()
+    # redefine the heading 2 block from StoryBlock and use the motif heading template
+    h2 = blocks.CharBlock(
+        form_classname="title",
+        icon="title",
+        template="patterns/molecules/streamfield/blocks/heading2_motif_block.html",
+        group="Basics",
+    )
+    # redefine the paragraph block from StoryBlock to exclude the h2 option
+    paragraph = blocks.RichTextBlock(
+        icon="pilcrow",
+        template="patterns/molecules/streamfield/blocks/paragraph_block.html",
+        features=['h3', 'h4', 'bold', 'italic', 'ul', 'ol', 'link', 'document-link'],
+        group="Basics",
+    )
+

--- a/tbx/static_src/sass/components/_grid.scss
+++ b/tbx/static_src/sass/components/_grid.scss
@@ -368,13 +368,18 @@
 
     // Service page alignment
     .template-service-page & {
-        // note that paragraph blocks are not overridden as they use the standard page position,
-        // further indented than the other page elements
         &__heading,
         &__intro,
         &__title {
             @include media-query(large) {
                 grid-column: 2 / span 9;
+            }
+        }
+
+        // paragraph block is indented further than other page elements
+        &__paragraph {
+            @include media-query(large) {
+                grid-column: 5 / span 7;
             }
         }
 

--- a/tbx/static_src/sass/components/_grid.scss
+++ b/tbx/static_src/sass/components/_grid.scss
@@ -368,11 +368,23 @@
 
     // Service page alignment
     .template-service-page & {
+        // note that paragraph blocks are not overridden as they use the standard page position,
+        // further indented than the other page elements
         &__heading,
         &__intro,
         &__title {
             @include media-query(large) {
                 grid-column: 2 / span 9;
+            }
+        }
+
+        // heading 2s on the service page use the motif heading style which needs extra spacing
+        &__heading--motif {
+            margin-bottom: $spacer-small-plus;
+
+            @include media-query(large) {
+                grid-column: 2 / span 9;
+                margin-bottom: $spacer-medium;
             }
         }
 
@@ -386,8 +398,7 @@
         }
 
         &__raw-html,
-        &__markdown,
-        &__paragraph {
+        &__markdown {
             @include media-query(large) {
                 grid-column: 2 / span 7;
             }


### PR DESCRIPTION
[Link to Ticket](https://torchbox.monday.com/boards/1192293412/pulses/1467968011)

### Description of Changes Made

- Override the heading 2 block on service pages, so that they use the motif heading style
- Remove the option to add a heading 2 block within a paragraph block on service pages (have confirmed these are not in use so no data migration necessary)
- Indent the paragraph blocks on service pages as requested by Ben
- Add extra margin below the motif heading 2 blocks

### How to Test

- Pull production data
- Check any existing h2s on service pages are using the motif style
- Check that paragraph blocks are indented - e.g. http://localhost:8000/services/wagtail-cms-services/wagtail-staff-augmentation/

### Screenshots

<details>
  <summary>Expand to see more</summary>

![screencapture-localhost-8000-services-wagtail-cms-services-wagtail-staff-augmentation-2024-04-17-11_36_09](https://github.com/torchbox/torchbox.com/assets/771869/9318c539-58d9-42fa-a04a-a6401c16aeb9)


</details>

### MR Checklist

- [x] Add a description of your pull request and instructions for the reviewer to verify your work.
- [x] If your pull request is for a specific ticket, link to it in the description.
- [x] Stay on point and keep it small so the merge request can be easily reviewed.
- [ ] Tests and linting passes.

#### Unit tests

- [ ] Added
- [x] Not required

#### Documentation

- [ ] Updated build docs
- [ ] Updated editor guidelines (https://docs.google.com/document/d/1PAWccdQ4tfaZsrEWmpDhvP3GH5RRmBOARFVp4b-kje8/edit?usp=sharing)
- [x] Not required

#### Browser testing

- [x] I have tested in the following browsers and environments (edit the list as required)
  - Latest version of Chrome on mac
- [ ] Not required

#### Data protection

- [x] Not relevant
- [ ] This adds new sources of PII and documents it and modifies Birdbath processors accordingly

#### Accessibility

- [x] Automated WCAG 2.1 tests pass
- [x] HTML validation passes
- [ ] Manual WCAG 2.1 tests completed
- [ ] I have tested in a screen reader
- [ ] I have tested in high-contrast mode
- [ ] Any animations removed for prefers-reduced-motion
- [ ] Not required

#### Sustainability

- [ ] Images are optimised and lazy-loading used where appropriate
- [ ] SVGs have been optimised
- [ ] Perfomance and transfer of data considered
- [ ] If JavaScript is needed alternatives have been considered
- [x] Not required

#### Pattern library

- [x] The pattern library component for this template displays correctly, and does not break parent templates
- [ ] The styleguide is updated if relevant
- [ ] Changes are not relevant the pattern library
