### PR TITLE
Fix issues with live previews when creating a PersonPage

### DIFF
--- a/tbx/people/models.py
+++ b/tbx/people/models.py
@@ -206,9 +206,15 @@ class PersonPage(ColourThemeMixin, ContactMixin, SocialFields, Page):
 
     @cached_property
     def author_posts(self):
-        author_snippet = Author.objects.get(person_page__pk=self.pk)
         # this import is added here in order to avoid circular imports
         from tbx.blog.models import BlogPage
+
+        try:
+            author_snippet = Author.objects.get(person_page__pk=self.pk)
+        except Author.DoesNotExist:
+            return []
+        except Author.MultipleObjectsReturned:
+            return []
 
         # Format for template
         return [
@@ -229,6 +235,12 @@ class PersonPage(ColourThemeMixin, ContactMixin, SocialFields, Page):
         """Returns work pages authored by the person, giving preference to Work rather than Historical work pages"""
         # this import is added here in order to avoid circular imports
         from tbx.work.models import HistoricalWorkPage, WorkPage
+
+        # only do this if page has been created
+        # otherwise you get misleading results during preview
+        # when creating a new page
+        if not self.pk:
+            return []
 
         # Get the latest 3 work pages by this author
         recent_works = (


### PR DESCRIPTION
[Link to Ticket](https://torchbox.monday.com/boards/1192293412/pulses/1463252135)

### Description of Changes Made

During a live preview when creating a PersonPage, there was an error occuring as follows:

<details>
  <summary>Details</summary>

```console
08:40:47 web.1      | [18/Apr/2024 04:40:47] "POST /admin/pages/add/people/personpage/13/preview/ HTTP/1.1" 200 40
08:40:49 web.1      | [2024-04-18 04:40:49,415][2041][ERROR][django.request] Internal Server Error: /about/team/foo-bar/
08:40:49 web.1      | Traceback (most recent call last):
08:40:49 web.1      |   File "/venv/lib/python3.11/site-packages/django/template/base.py", line 880, in _resolve_lookup
08:40:49 web.1      |     current = current[bit]
08:40:49 web.1      |               ~~~~~~~^^^^^
08:40:49 web.1      | TypeError: 'PersonPage' object is not subscriptable
08:40:49 web.1      | 
08:40:49 web.1      | During handling of the above exception, another exception occurred:
08:40:49 web.1      | 
08:40:49 web.1      | Traceback (most recent call last):
08:40:49 web.1      |   File "/venv/lib/python3.11/site-packages/django/core/handlers/exception.py", line 55, in inner
08:40:49 web.1      |     response = get_response(request)
08:40:49 web.1      |                ^^^^^^^^^^^^^^^^^^^^^
08:40:49 web.1      |   File "/venv/lib/python3.11/site-packages/wagtail/models/__init__.py", line 680, in _get_response
08:40:49 web.1      |     response = response.render()
08:40:49 web.1      |                ^^^^^^^^^^^^^^^^^
08:40:49 web.1      |   File "/venv/lib/python3.11/site-packages/django/template/response.py", line 114, in render
08:40:49 web.1      |     self.content = self.rendered_content
08:40:49 web.1      |                    ^^^^^^^^^^^^^^^^^^^^^
08:40:49 web.1      |   File "/venv/lib/python3.11/site-packages/django/template/response.py", line 92, in rendered_content
08:40:49 web.1      |     return template.render(context, self._request)
08:40:49 web.1      |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
08:40:49 web.1      |   File "/venv/lib/python3.11/site-packages/django/template/backends/django.py", line 61, in render
08:40:49 web.1      |     return self.template.render(context)
08:40:49 web.1      |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
08:40:49 web.1      |   File "/venv/lib/python3.11/site-packages/django/template/base.py", line 175, in render
08:40:49 web.1      |     return self._render(context)
08:40:49 web.1      |            ^^^^^^^^^^^^^^^^^^^^^
08:40:49 web.1      |   File "/venv/lib/python3.11/site-packages/django/test/utils.py", line 112, in instrumented_test_render
08:40:49 web.1      |     return self.nodelist.render(context)
08:40:49 web.1      |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
08:40:49 web.1      |   File "/venv/lib/python3.11/site-packages/django/template/base.py", line 1005, in render
08:40:49 web.1      |     return SafeString("".join([node.render_annotated(context) for node in self]))
08:40:49 web.1      |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
08:40:49 web.1      |   File "/venv/lib/python3.11/site-packages/django/template/base.py", line 1005, in <listcomp>
08:40:49 web.1      |     return SafeString("".join([node.render_annotated(context) for node in self]))
08:40:49 web.1      |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
08:40:49 web.1      |   File "/venv/lib/python3.11/site-packages/django/template/base.py", line 966, in render_annotated
08:40:49 web.1      |     return self.render(context)
08:40:49 web.1      |            ^^^^^^^^^^^^^^^^^^^^
08:40:49 web.1      |   File "/venv/lib/python3.11/site-packages/pattern_library/loader_tags.py", line 38, in render
08:40:49 web.1      |     return super().render(context)
08:40:49 web.1      |            ^^^^^^^^^^^^^^^^^^^^^^^
08:40:49 web.1      |   File "/venv/lib/python3.11/site-packages/django/template/loader_tags.py", line 157, in render
08:40:49 web.1      |     return compiled_parent._render(context)
08:40:49 web.1      |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
08:40:49 web.1      |   File "/venv/lib/python3.11/site-packages/django/test/utils.py", line 112, in instrumented_test_render
08:40:49 web.1      |     return self.nodelist.render(context)
08:40:49 web.1      |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
08:40:49 web.1      |   File "/venv/lib/python3.11/site-packages/django/template/base.py", line 1005, in render
08:40:49 web.1      |     return SafeString("".join([node.render_annotated(context) for node in self]))
08:40:49 web.1      |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
08:40:49 web.1      |   File "/venv/lib/python3.11/site-packages/django/template/base.py", line 1005, in <listcomp>
08:40:49 web.1      |     return SafeString("".join([node.render_annotated(context) for node in self]))
08:40:49 web.1      |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
08:40:49 web.1      |   File "/venv/lib/python3.11/site-packages/django/template/base.py", line 966, in render_annotated
08:40:49 web.1      |     return self.render(context)
08:40:49 web.1      |            ^^^^^^^^^^^^^^^^^^^^
08:40:49 web.1      |   File "/venv/lib/python3.11/site-packages/pattern_library/loader_tags.py", line 38, in render
08:40:49 web.1      |     return super().render(context)
08:40:49 web.1      |            ^^^^^^^^^^^^^^^^^^^^^^^
08:40:49 web.1      |   File "/venv/lib/python3.11/site-packages/django/template/loader_tags.py", line 157, in render
08:40:49 web.1      |     return compiled_parent._render(context)
08:40:49 web.1      |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
08:40:49 web.1      |   File "/venv/lib/python3.11/site-packages/django/test/utils.py", line 112, in instrumented_test_render
08:40:49 web.1      |     return self.nodelist.render(context)
08:40:49 web.1      |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
08:40:49 web.1      |   File "/venv/lib/python3.11/site-packages/django/template/base.py", line 1005, in render
08:40:49 web.1      |     return SafeString("".join([node.render_annotated(context) for node in self]))
08:40:49 web.1      |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
08:40:49 web.1      |   File "/venv/lib/python3.11/site-packages/django/template/base.py", line 1005, in <listcomp>
08:40:49 web.1      |     return SafeString("".join([node.render_annotated(context) for node in self]))
08:40:49 web.1      |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
08:40:49 web.1      |   File "/venv/lib/python3.11/site-packages/django/template/base.py", line 966, in render_annotated
08:40:49 web.1      |     return self.render(context)
08:40:49 web.1      |            ^^^^^^^^^^^^^^^^^^^^
08:40:49 web.1      |   File "/venv/lib/python3.11/site-packages/django/template/loader_tags.py", line 63, in render
08:40:49 web.1      |     result = block.nodelist.render(context)
08:40:49 web.1      |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
08:40:49 web.1      |   File "/venv/lib/python3.11/site-packages/django/template/base.py", line 1005, in render
08:40:49 web.1      |     return SafeString("".join([node.render_annotated(context) for node in self]))
08:40:49 web.1      |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
08:40:49 web.1      |   File "/venv/lib/python3.11/site-packages/django/template/base.py", line 1005, in <listcomp>
08:40:49 web.1      |     return SafeString("".join([node.render_annotated(context) for node in self]))
08:40:49 web.1      |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
08:40:49 web.1      |   File "/venv/lib/python3.11/site-packages/django/template/base.py", line 966, in render_annotated
08:40:49 web.1      |     return self.render(context)
08:40:49 web.1      |            ^^^^^^^^^^^^^^^^^^^^
08:40:49 web.1      |   File "/venv/lib/python3.11/site-packages/django/template/defaulttags.py", line 314, in render
08:40:49 web.1      |     match = condition.eval(context)
08:40:49 web.1      |             ^^^^^^^^^^^^^^^^^^^^^^^
08:40:49 web.1      |   File "/venv/lib/python3.11/site-packages/django/template/defaulttags.py", line 877, in eval
08:40:49 web.1      |     return self.value.resolve(context, ignore_failures=True)
08:40:49 web.1      |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
08:40:49 web.1      |   File "/venv/lib/python3.11/site-packages/django/template/base.py", line 715, in resolve
08:40:49 web.1      |     obj = self.var.resolve(context)
08:40:49 web.1      |           ^^^^^^^^^^^^^^^^^^^^^^^^^
08:40:49 web.1      |   File "/venv/lib/python3.11/site-packages/django/template/base.py", line 847, in resolve
08:40:49 web.1      |     value = self._resolve_lookup(context)
08:40:49 web.1      |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
08:40:49 web.1      |   File "/venv/lib/python3.11/site-packages/django/template/base.py", line 890, in _resolve_lookup
08:40:49 web.1      |     current = getattr(current, bit)
08:40:49 web.1      |               ^^^^^^^^^^^^^^^^^^^^^
08:40:49 web.1      |   File "/venv/lib/python3.11/site-packages/django/utils/functional.py", line 57, in __get__
08:40:49 web.1      |     res = instance.__dict__[self.name] = self.func(instance)
08:40:49 web.1      |                                          ^^^^^^^^^^^^^^^^^^^
08:40:49 web.1      |   File "/app/fooapp/people/models.py", line 209, in author_posts
08:40:49 web.1      |     author_snippet = Author.objects.get(person_page__pk=self.pk)
08:40:49 web.1      |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
08:40:49 web.1      |   File "/venv/lib/python3.11/site-packages/django/db/models/manager.py", line 87, in manager_method
08:40:49 web.1      |     return getattr(self.get_queryset(), name)(*args, **kwargs)
08:40:49 web.1      |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
08:40:49 web.1      |   File "/venv/lib/python3.11/site-packages/django/db/models/query.py", line 640, in get
08:40:49 web.1      |     raise self.model.MultipleObjectsReturned(
08:40:49 web.1      | fooapp.people.models.Author.MultipleObjectsReturned: get() returned more than one Author -- it returned 5!
```
</details>

This PR fixes this error, by wrapping the `Author.objects.get()` call in a try...catch block and and handling `obj.MultipleObjectsReturned` and `obj.ObjectDoesNotExist` exceptions.

I also noticed that when previewing a page (before it's saved), the preview showed some `related_works`, which, when queried, were historical work pages where the author was deleted. I therefore added a small condition in the `related_works` cached property, where we return nothing if the page is not saved. 

Might be worth checking these pages and ensure that the author is specified, if necessary:

```console
>>> qs = HistoricalWorkPage.objects.live().filter(authors__author__isnull=True).values_list('id', 'url_path', 'title')
>>> from pprint import pprint as pp
>>> pp(list(qs), indent=2)
[ ( 47,
    '/torchbox/work/university-of-oxford/',
    "Multi-awarding winning site for one of the world's leading universities"),
  ( 315,
    '/torchbox/work/mediae/',
    'A SMS and call centre application for Kenyan farmers'),
  ( 625,
    '/torchbox/work/museum-of-london/',
    'Award-winning redesign delivers +50% increase in online income'),
  ( 1078,
    '/torchbox/work/meningitis-now-seo/',
    'An SEO Strategy for Meningitis Now'),
  ( 143,
    '/torchbox/work/chatham-house/',
    'A platform for policy research on international affairs'),
  (755, '/torchbox/work/mencap/', 'PPC Provides the Missing Link for Mencap'),
  ( 626,
    '/torchbox/work/africa-progress-panel/',
    'Raising awareness of People Power Planet'),
  ( 171,
    '/torchbox/work/bath-heritage-services/',
    "Redesigning Bath & North East Somerset Council's websites"),
  (526, '/torchbox/work/sgoss-school-makers/', 'SGOSS - Governors for Schools'),
  ( 443,
    '/torchbox/work/global-witness-google-grants/',
    'Driving User Engagement With Google Ad Grants'),
  (525, '/torchbox/work/ippf/', 'IPPF')]
>>> 
```

### How to Test

- Try to create a new PersonPage and ensure live preview panel is open.

### Screenshots

<details>
  <summary>Before</summary>

![Screenshot from 2024-04-18 04-42-56](https://github.com/torchbox/torchbox.com/assets/7713776/b3b128ff-45d3-4495-985a-308b3630a54b)

</details>

<details>
  <summary>After</summary>

![Screenshot from 2024-04-18 05-50-28](https://github.com/torchbox/torchbox.com/assets/7713776/3b1e1f8b-2cc4-4675-9370-246d5cb7572a)

</details>

### MR Checklist

- [x] Add a description of your pull request and instructions for the reviewer to verify your work.
- [x] If your pull request is for a specific ticket, link to it in the description.
- [x] Stay on point and keep it small so the merge request can be easily reviewed.
- [x] Tests and linting passes.

#### Unit tests

Didn't get the chance to add unit tests, but this is something that can be done perhaps later?

- [ ] Added
- [ ] Not required

#### Documentation

- [ ] Updated build docs
- [ ] Updated editor guidelines (https://docs.google.com/document/d/1PAWccdQ4tfaZsrEWmpDhvP3GH5RRmBOARFVp4b-kje8/edit?usp=sharing)
- [x] Not required

#### Browser testing

- [x] I have tested in the following browsers and environments (edit the list as required)
  - Latest version of Chrome on Ubuntu
  - Latest version of Firefox on Ubuntu

#### Data protection

- [ ] Not relevant
- [x] This adds new sources of PII and documents it and modifies Birdbath processors accordingly

#### Accessibility

- [ ] Automated WCAG 2.1 tests pass
- [ ] HTML validation passes
- [ ] Manual WCAG 2.1 tests completed
- [ ] I have tested in a screen reader
- [ ] I have tested in high-contrast mode
- [ ] Any animations removed for prefers-reduced-motion
- [x] Not required

#### Sustainability

- [ ] Images are optimised and lazy-loading used where appropriate
- [ ] SVGs have been optimised
- [ ] Perfomance and transfer of data considered
- [ ] If JavaScript is needed alternatives have been considered
- [x] Not required

#### Pattern library

- [ ] The pattern library component for this template displays correctly, and does not break parent templates
- [ ] The styleguide is updated if relevant
- [x] Changes are not relevant the pattern library
