### PR TITLE
Fixed nesting error in carbon statement

### DIFF
--- a/tbx/project_styleguide/templates/patterns/molecules/carbon-impact/carbon-impact.html
+++ b/tbx/project_styleguide/templates/patterns/molecules/carbon-impact/carbon-impact.html
@@ -1,7 +1,8 @@
 <div class="grid footer__carbon-impact-container" data-page-carbon>
     <div class="grid__carbon-impact">
         <div class="footer__carbon-impact">
-            <p class="footer__carbon-impact-text">Loading the site homepage emits just <span>0.07g of CO2</span> per view. <a href="/about/digital-emissions/" class="footer__carbon-impact-link"></p><p class="footer__carbon-impact-text">Find out more about our carbon impact</a></p>
+            <p class="footer__carbon-impact-text">Loading the site homepage emits just <span>0.07g of CO2</span> per view.</p>
+            <p class="footer__carbon-impact-text"><a href="/about/digital-emissions/" class="footer__carbon-impact-link">Find out more about our carbon impact</a></p>
         </div>
     </div>
 </div>


### PR DESCRIPTION
No ticket

### Description of Changes Made

I spotted there was an accessibility error with the footer digital emissions link - turned out to be incorrectly nested.

### How to Test

### Screenshots

<details>
  <summary>Expand to see more</summary>

</details>

### MR Checklist

- [ ] Add a description of your pull request and instructions for the reviewer to verify your work.
- [ ] If your pull request is for a specific ticket, link to it in the description.
- [ ] Stay on point and keep it small so the merge request can be easily reviewed.
- [ ] Tests and linting passes.

#### Unit tests

- [ ] Added
- [ ] Not required

#### Documentation

- [ ] Updated build docs
- [ ] Updated editor guidelines (https://docs.google.com/document/d/1PAWccdQ4tfaZsrEWmpDhvP3GH5RRmBOARFVp4b-kje8/edit?usp=sharing)
- [ ] Not required

#### Browser testing

- [ ] I have tested in the following browsers and environments (edit the list as required)
  - Latest version of Chrome on mac
- [ ] Not required

#### Data protection

- [ ] Not relevant
- [ ] This adds new sources of PII and documents it and modifies Birdbath processors accordingly

#### Accessibility

- [ ] Automated WCAG 2.1 tests pass
- [ ] HTML validation passes
- [ ] Manual WCAG 2.1 tests completed
- [ ] I have tested in a screen reader
- [ ] I have tested in high-contrast mode
- [ ] Any animations removed for prefers-reduced-motion
- [ ] Not required

#### Sustainability

- [ ] Images are optimised and lazy-loading used where appropriate
- [ ] SVGs have been optimised
- [ ] Perfomance and transfer of data considered
- [ ] If JavaScript is needed alternatives have been considered
- [ ] Not required

#### Pattern library

- [ ] The pattern library component for this template displays correctly, and does not break parent templates
- [ ] The styleguide is updated if relevant
- [ ] Changes are not relevant the pattern library
