### PR TITLE
Fix size of the regular showcase titles

### DIFF
--- a/tbx/static_src/sass/components/_showcase.scss
+++ b/tbx/static_src/sass/components/_showcase.scss
@@ -107,7 +107,7 @@
     }
 
     &__heading {
-        @include font-size(heading-three-b);
+        @include font-size(heading-four);
         font-weight: $weight--semibold;
         margin-bottom: $spacer-mini;
 
@@ -120,7 +120,9 @@
             gap: $spacer-mini;
         }
 
+        // home page showcase block only
         &--with-tail {
+            @include font-size(heading-three-b);
             display: block;
         }
     }


### PR DESCRIPTION
[Link to Ticket](https://torchbox.monday.com/boards/1192293412/pulses/1468065240)

### Description of Changes Made

Reverts showcase block heading size. Applies the size change to the homepage version only.

### How to Test

Review pattern library or add showcase block on homepage and compare with service page.

### MR Checklist

- [x] Add a description of your pull request and instructions for the reviewer to verify your work.
- [x] If your pull request is for a specific ticket, link to it in the description.
- [x] Stay on point and keep it small so the merge request can be easily reviewed.
- [x] Tests and linting passes.

#### Unit tests

- [ ] Added
- [x] Not required

#### Documentation

- [ ] Updated build docs
- [ ] Updated editor guidelines (https://docs.google.com/document/d/1PAWccdQ4tfaZsrEWmpDhvP3GH5RRmBOARFVp4b-kje8/edit?usp=sharing)
- [x] Not required

#### Browser testing

- [ ] I have tested in the following browsers and environments (edit the list as required)
  - Latest version of Chrome on mac
  - Latest version of Firefox on mac
  - Latest version of Safari on mac
  - Safari on last two versions of iOS
  - Chrome on last two versions of Android
- [x] Not required

#### Data protection

- [x] Not relevant
- [ ] This adds new sources of PII and documents it and modifies Birdbath processors accordingly

#### Accessibility

- [ ] Automated WCAG 2.1 tests pass
- [ ] HTML validation passes
- [ ] Manual WCAG 2.1 tests completed
- [ ] I have tested in a screen reader
- [ ] I have tested in high-contrast mode
- [ ] Any animations removed for prefers-reduced-motion
- [x] Not required

#### Sustainability

- [ ] Images are optimised and lazy-loading used where appropriate
- [ ] SVGs have been optimised
- [ ] Perfomance and transfer of data considered
- [ ] If JavaScript is needed alternatives have been considered
- [x] Not required

#### Pattern library

- [x] The pattern library component for this template displays correctly, and does not break parent templates
- [ ] The styleguide is updated if relevant
- [ ] Changes are not relevant the pattern library
