### PR TITLE
Tighten up spacing after narrower letters

### DIFF
--- a/docs/front-end/motif-headings.md
+++ b/docs/front-end/motif-headings.md
@@ -1,0 +1,7 @@
+# Motif headings
+
+The site makes use of coloured drop-cap letters in major headings, with an optional animation on heading ones.
+
+Because some letters are narrower than others, there was an issue with a large gap after the initial drop-cap, as well as an issue with the letter I where it was too narrow to see the final background flame image. This has been solved with some custom classes for particular letters.
+
+See the `motif-heading.html` component (under `atoms` in the styleguide) and the equivalent `motif-heading.scss` sass file.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -72,6 +72,7 @@ nav:
       - front-end/tooling.md
       - front-end/placeholder-images.md
       - front-end/utility-classes.md
+      - front-end/motif-headings.md
       - 'Markdown block and codehilite': 'front-end/markdown-codehilite.md'
       - front-end/impact-report.md
       - front-end/lite-youtube.md

--- a/tbx/project_styleguide/templates/patterns/atoms/motif-heading/motif-heading.html
+++ b/tbx/project_styleguide/templates/patterns/atoms/motif-heading/motif-heading.html
@@ -1,5 +1,5 @@
 <h{{ heading_level|default:1 }} class="motif-heading {% if classes %}{{ classes }}{% endif %}" aria-label="{% firstof aria_label heading %}">
     {% with first_letter=heading|slice:":1" %}
-        <span class="motif-heading__drop-cap {% if first_letter|lower == 'i' %}motif-heading__drop-cap--i{% endif %} {% if first_letter|lower in 'f,p,w' %}motif-heading__drop-cap--narrow{% endif %} {% if first_letter|lower in 't,y' %}motif-heading__drop-cap--narrowest{% endif %}">{{ first_letter }}</span><span>{{ heading|slice:"1:" }}</span>
+        <span class="motif-heading__drop-cap {% if first_letter|lower == 'i' %}motif-heading__drop-cap--i{% endif %} {% if first_letter|lower in 'f,p' %}motif-heading__drop-cap--narrow{% endif %} {% if first_letter|lower == 'w' %}motif-heading__drop-cap--narrower{% endif %} {% if first_letter|lower in 't,y' %}motif-heading__drop-cap--narrowest{% endif %}">{{ first_letter }}</span><span>{{ heading|slice:"1:" }}</span>
     {% endwith %}
 </h{{ heading_level|default:1 }}>

--- a/tbx/project_styleguide/templates/patterns/atoms/motif-heading/motif-heading.html
+++ b/tbx/project_styleguide/templates/patterns/atoms/motif-heading/motif-heading.html
@@ -1,5 +1,5 @@
 <h{{ heading_level|default:1 }} class="motif-heading {% if classes %}{{ classes }}{% endif %}" aria-label="{% firstof aria_label heading %}">
     {% with first_letter=heading|slice:":1" %}
-        <span class="motif-heading__drop-cap {% if first_letter|lower == "i" %}motif-heading__drop-cap--i{% endif %}">{{ first_letter }}</span>{{ heading|slice:"1:" }}
+        <span class="motif-heading__drop-cap {% if first_letter|lower == 'i' %}motif-heading__drop-cap--i{% endif %} {% if first_letter|lower in 'f,p,w' %}motif-heading__drop-cap--narrow{% endif %} {% if first_letter|lower in 't,y' %}motif-heading__drop-cap--narrowest{% endif %}">{{ first_letter }}</span><span>{{ heading|slice:"1:" }}</span>
     {% endwith %}
 </h{{ heading_level|default:1 }}>

--- a/tbx/project_styleguide/templates/patterns/styleguide/typography/typography.html
+++ b/tbx/project_styleguide/templates/patterns/styleguide/typography/typography.html
@@ -2,10 +2,43 @@
     {# Headings #}
     <p class="underline mt-8">Heading 1</p>
     {% include "patterns/atoms/motif-heading/motif-heading.html" with heading_level=1 classes="motif-heading--one" %}
+
+    <p class="underline mt-8">Heading 1 with the 'narrowest' motif class</p>
+    {% include "patterns/atoms/motif-heading/motif-heading.html" with heading_level=1 classes="motif-heading--one" heading="Thinking" %}
+    {% include "patterns/atoms/motif-heading/motif-heading.html" with heading_level=1 classes="motif-heading--one" heading="Yikes" %}
+
+    <p class="underline mt-8">Heading 1 with the 'narrow' motif class</p>
+    {% include "patterns/atoms/motif-heading/motif-heading.html" with heading_level=1 classes="motif-heading--one" heading="Flight" %}
+    {% include "patterns/atoms/motif-heading/motif-heading.html" with heading_level=1 classes="motif-heading--one" heading="Platitude" %}
+    {% include "patterns/atoms/motif-heading/motif-heading.html" with heading_level=1 classes="motif-heading--one" heading="Which" %}
+
+
     <p class="underline mt-8">Heading 1-B</p>
     {% include "patterns/atoms/motif-heading/motif-heading.html" with heading_level=1 classes="motif-heading--one-b" %}
+
+    <p class="underline mt-8">Heading 1-B with the 'narrowest' motif class</p>
+    {% include "patterns/atoms/motif-heading/motif-heading.html" with heading_level=1 classes="motif-heading--one-b" heading="Thinking" %}
+    {% include "patterns/atoms/motif-heading/motif-heading.html" with heading_level=1 classes="motif-heading--one-b" heading="Yikes" %}
+
+    <p class="underline mt-8">Heading 1-B with the 'narrow' motif class</p>
+    {% include "patterns/atoms/motif-heading/motif-heading.html" with heading_level=1 classes="motif-heading--one-b" heading="Flight" %}
+    {% include "patterns/atoms/motif-heading/motif-heading.html" with heading_level=1 classes="motif-heading--one-b" heading="Platitude" %}
+    {% include "patterns/atoms/motif-heading/motif-heading.html" with heading_level=1 classes="motif-heading--one-b" heading="Which" %}
+
+
     <p class="underline mt-8">Heading 2</p>
     {% include "patterns/atoms/motif-heading/motif-heading.html" with heading_level=2 classes="motif-heading--two" %}
+
+    <p class="underline mt-8">Heading 2 with the 'narrowest' motif class</p>
+    {% include "patterns/atoms/motif-heading/motif-heading.html" with heading_level=2 classes="motif-heading--two" heading="Thinking"%}
+    {% include "patterns/atoms/motif-heading/motif-heading.html" with heading_level=2 classes="motif-heading--two" heading="Yikes"%}
+
+    <p class="underline mt-8">Heading 2 with the 'narrow' motif class</p>
+    {% include "patterns/atoms/motif-heading/motif-heading.html" with heading_level=2 classes="motif-heading--two" heading="Flight"%}
+    {% include "patterns/atoms/motif-heading/motif-heading.html" with heading_level=2 classes="motif-heading--two" heading="Platitude"%}
+    {% include "patterns/atoms/motif-heading/motif-heading.html" with heading_level=2 classes="motif-heading--two" heading="Which"%}
+
+
     <p class="underline mt-8">Heading 2-B</p>
     <h2 class="heading heading--two-b">Joining the battle to protect our oceans</h2>
     <p class="underline mt-8">Heading 3</p>

--- a/tbx/project_styleguide/templates/patterns/styleguide/typography/typography.html
+++ b/tbx/project_styleguide/templates/patterns/styleguide/typography/typography.html
@@ -7,12 +7,15 @@
     {% include "patterns/atoms/motif-heading/motif-heading.html" with heading_level=1 classes="motif-heading--one" heading="Thinking" %}
     {% include "patterns/atoms/motif-heading/motif-heading.html" with heading_level=1 classes="motif-heading--one" heading="Yikes" %}
 
+    <p class="underline mt-8">Heading 1 with the 'narrower' drop-cap class</p>
+    {% include "patterns/atoms/motif-heading/motif-heading.html" with heading_level=1 classes="motif-heading--one" heading="Which" %}
+
     <p class="underline mt-8">Heading 1 with the 'narrow' drop-cap class</p>
     {% include "patterns/atoms/motif-heading/motif-heading.html" with heading_level=1 classes="motif-heading--one" heading="Flight" %}
     {% include "patterns/atoms/motif-heading/motif-heading.html" with heading_level=1 classes="motif-heading--one" heading="Platitude" %}
-    {% include "patterns/atoms/motif-heading/motif-heading.html" with heading_level=1 classes="motif-heading--one" heading="Which" %}
 
-    <p class="underline mt-8">Heading 1 with the special I class</p>
+
+    <p class="underline mt-8">Heading 1 with the 'i' drop-cap class</p>
     {% include "patterns/atoms/motif-heading/motif-heading.html" with heading_level=1 classes="motif-heading--one" heading="Inventory" %}
 
 
@@ -23,10 +26,12 @@
     {% include "patterns/atoms/motif-heading/motif-heading.html" with heading_level=1 classes="motif-heading--one-b" heading="Thinking" %}
     {% include "patterns/atoms/motif-heading/motif-heading.html" with heading_level=1 classes="motif-heading--one-b" heading="Yikes" %}
 
+    <p class="underline mt-8">Heading 1-B with the 'narrower' drop-cap class</p>
+    {% include "patterns/atoms/motif-heading/motif-heading.html" with heading_level=1 classes="motif-heading--one-b" heading="Which" %}
+
     <p class="underline mt-8">Heading 1-B with the 'narrow' drop-cap class</p>
     {% include "patterns/atoms/motif-heading/motif-heading.html" with heading_level=1 classes="motif-heading--one-b" heading="Flight" %}
     {% include "patterns/atoms/motif-heading/motif-heading.html" with heading_level=1 classes="motif-heading--one-b" heading="Platitude" %}
-    {% include "patterns/atoms/motif-heading/motif-heading.html" with heading_level=1 classes="motif-heading--one-b" heading="Which" %}
 
 
     <p class="underline mt-8">Heading 2</p>
@@ -36,10 +41,12 @@
     {% include "patterns/atoms/motif-heading/motif-heading.html" with heading_level=2 classes="motif-heading--two" heading="Thinking"%}
     {% include "patterns/atoms/motif-heading/motif-heading.html" with heading_level=2 classes="motif-heading--two" heading="Yikes"%}
 
+    <p class="underline mt-8">Heading 2 with the 'narrower' drop-cap class</p>
+    {% include "patterns/atoms/motif-heading/motif-heading.html" with heading_level=2 classes="motif-heading--two" heading="Which"%}
+
     <p class="underline mt-8">Heading 2 with the 'narrow' drop-cap class</p>
     {% include "patterns/atoms/motif-heading/motif-heading.html" with heading_level=2 classes="motif-heading--two" heading="Flight"%}
     {% include "patterns/atoms/motif-heading/motif-heading.html" with heading_level=2 classes="motif-heading--two" heading="Platitude"%}
-    {% include "patterns/atoms/motif-heading/motif-heading.html" with heading_level=2 classes="motif-heading--two" heading="Which"%}
 
 
     <p class="underline mt-8">Heading 2-B</p>

--- a/tbx/project_styleguide/templates/patterns/styleguide/typography/typography.html
+++ b/tbx/project_styleguide/templates/patterns/styleguide/typography/typography.html
@@ -3,24 +3,27 @@
     <p class="underline mt-8">Heading 1</p>
     {% include "patterns/atoms/motif-heading/motif-heading.html" with heading_level=1 classes="motif-heading--one" %}
 
-    <p class="underline mt-8">Heading 1 with the 'narrowest' motif class</p>
+    <p class="underline mt-8">Heading 1 with the 'narrowest' drop-cap class</p>
     {% include "patterns/atoms/motif-heading/motif-heading.html" with heading_level=1 classes="motif-heading--one" heading="Thinking" %}
     {% include "patterns/atoms/motif-heading/motif-heading.html" with heading_level=1 classes="motif-heading--one" heading="Yikes" %}
 
-    <p class="underline mt-8">Heading 1 with the 'narrow' motif class</p>
+    <p class="underline mt-8">Heading 1 with the 'narrow' drop-cap class</p>
     {% include "patterns/atoms/motif-heading/motif-heading.html" with heading_level=1 classes="motif-heading--one" heading="Flight" %}
     {% include "patterns/atoms/motif-heading/motif-heading.html" with heading_level=1 classes="motif-heading--one" heading="Platitude" %}
     {% include "patterns/atoms/motif-heading/motif-heading.html" with heading_level=1 classes="motif-heading--one" heading="Which" %}
+
+    <p class="underline mt-8">Heading 1 with the special I class</p>
+    {% include "patterns/atoms/motif-heading/motif-heading.html" with heading_level=1 classes="motif-heading--one" heading="Inventory" %}
 
 
     <p class="underline mt-8">Heading 1-B</p>
     {% include "patterns/atoms/motif-heading/motif-heading.html" with heading_level=1 classes="motif-heading--one-b" %}
 
-    <p class="underline mt-8">Heading 1-B with the 'narrowest' motif class</p>
+    <p class="underline mt-8">Heading 1-B with the 'narrowest' drop-cap class</p>
     {% include "patterns/atoms/motif-heading/motif-heading.html" with heading_level=1 classes="motif-heading--one-b" heading="Thinking" %}
     {% include "patterns/atoms/motif-heading/motif-heading.html" with heading_level=1 classes="motif-heading--one-b" heading="Yikes" %}
 
-    <p class="underline mt-8">Heading 1-B with the 'narrow' motif class</p>
+    <p class="underline mt-8">Heading 1-B with the 'narrow' drop-cap class</p>
     {% include "patterns/atoms/motif-heading/motif-heading.html" with heading_level=1 classes="motif-heading--one-b" heading="Flight" %}
     {% include "patterns/atoms/motif-heading/motif-heading.html" with heading_level=1 classes="motif-heading--one-b" heading="Platitude" %}
     {% include "patterns/atoms/motif-heading/motif-heading.html" with heading_level=1 classes="motif-heading--one-b" heading="Which" %}
@@ -29,11 +32,11 @@
     <p class="underline mt-8">Heading 2</p>
     {% include "patterns/atoms/motif-heading/motif-heading.html" with heading_level=2 classes="motif-heading--two" %}
 
-    <p class="underline mt-8">Heading 2 with the 'narrowest' motif class</p>
+    <p class="underline mt-8">Heading 2 with the 'narrowest' drop-cap class</p>
     {% include "patterns/atoms/motif-heading/motif-heading.html" with heading_level=2 classes="motif-heading--two" heading="Thinking"%}
     {% include "patterns/atoms/motif-heading/motif-heading.html" with heading_level=2 classes="motif-heading--two" heading="Yikes"%}
 
-    <p class="underline mt-8">Heading 2 with the 'narrow' motif class</p>
+    <p class="underline mt-8">Heading 2 with the 'narrow' drop-cap class</p>
     {% include "patterns/atoms/motif-heading/motif-heading.html" with heading_level=2 classes="motif-heading--two" heading="Flight"%}
     {% include "patterns/atoms/motif-heading/motif-heading.html" with heading_level=2 classes="motif-heading--two" heading="Platitude"%}
     {% include "patterns/atoms/motif-heading/motif-heading.html" with heading_level=2 classes="motif-heading--two" heading="Which"%}

--- a/tbx/static_src/sass/components/_motif-heading.scss
+++ b/tbx/static_src/sass/components/_motif-heading.scss
@@ -44,7 +44,12 @@
             margin-left: -0.3em;
         }
 
-        // Affects F,P and W
+        // Affects W
+        &--narrower + span {
+            margin-left: -0.15em;
+        }
+
+        // Affects F and P
         &--narrow + span {
             margin-left: -0.05em;
         }

--- a/tbx/static_src/sass/components/_motif-heading.scss
+++ b/tbx/static_src/sass/components/_motif-heading.scss
@@ -15,6 +15,7 @@
         -webkit-text-fill-color: transparent;
         animation: motifAnimation 1.7s cubic-bezier(0.3, 0, 0.6, 1);
         background-origin: border-box;
+        text-transform: uppercase;
 
         @include reduced-motion() {
             animation: none;
@@ -24,6 +25,8 @@
             animation: none;
         }
 
+        // The letter I gets a special version of the animation so that the flame
+        // is visible in its final resting place
         &--i {
             background-size: 200%;
             animation: motifAnimationForLeterI 1.7s cubic-bezier(0.3, 0, 0.6, 1)
@@ -32,6 +35,18 @@
             @include reduced-motion() {
                 animation: none;
             }
+        }
+
+        // Narrower letters look like they have too much space after them
+        // These classes add a small negative margin on the letters after - using ems to work for different font-sizes
+        // Affects T and Y
+        &--narrowest + span {
+            margin-left: -0.3em;
+        }
+
+        // Affects F,P and W
+        &--narrow + span {
+            margin-left: -0.05em;
         }
     }
 


### PR DESCRIPTION
[Link to Ticket](https://torchbox.monday.com/boards/1192293412/pulses/1368002941)

### Description of Changes Made

Three new variant classes added:

`motif-heading--narrowest`, `motif-heading--narrower` and `motif-heading--narrow`

The following text is now wrapped in a span too, and a sibling class selector is used to add a small negative margin on the letters that follow. Setting a negative `letter-spacing` value did not work, as it cut off part of the drop-cap letter.

### How to Test

http://localhost:8000/pattern-library/pattern/patterns/styleguide/typography/typography.html shows all the narrow, narrower and narrowest heading variants

Also test headings in the build with different starting letters to check the classes are applied correctly.

### Screenshots

<details>
  <summary>Expand to see more</summary>

![Screenshot 2024-04-24 at 13 22 42](https://github.com/torchbox/torchbox.com/assets/771869/f74a0963-14e5-490c-ac4a-dfc5db098cfd)

</details>

### MR Checklist

- [x] Add a description of your pull request and instructions for the reviewer to verify your work.
- [x] If your pull request is for a specific ticket, link to it in the description.
- [x] Stay on point and keep it small so the merge request can be easily reviewed.
- [x] Tests and linting passes.

#### Unit tests

- [ ] Added
- [x] Not required

#### Documentation

- [x] Updated build docs
- [ ] Updated editor guidelines (https://docs.google.com/document/d/1PAWccdQ4tfaZsrEWmpDhvP3GH5RRmBOARFVp4b-kje8/edit?usp=sharing)
- [ ] Not required

#### Browser testing

- [x] I have tested in the following browsers and environments (edit the list as required)
  - Latest version of Chrome on mac
  - Latest version of Firefox on mac
  - Latest version of Safari on mac
  - Safari on last two versions of iOS
  - Chrome on last two versions of Android
- [ ] Not required

#### Data protection

- [x] Not relevant
- [ ] This adds new sources of PII and documents it and modifies Birdbath processors accordingly

#### Accessibility

- [x] Automated WCAG 2.1 tests pass
- [x] HTML validation passes
- [ ] Manual WCAG 2.1 tests completed
- [x] I have tested in a screen reader
- [x] I have tested in high-contrast mode
- [ ] Any animations removed for prefers-reduced-motion
- [ ] Not required

#### Sustainability

- [ ] Images are optimised and lazy-loading used where appropriate
- [ ] SVGs have been optimised
- [ ] Perfomance and transfer of data considered
- [ ] If JavaScript is needed alternatives have been considered
- [x] Not required

#### Pattern library

- [x] The pattern library component for this template displays correctly, and does not break parent templates
- [x] The styleguide is updated if relevant
- [ ] Changes are not relevant the pattern library
