### PR TITLE
Add support runbook

### DIFF
--- a/docs/support-runbook.md
+++ b/docs/support-runbook.md
@@ -61,6 +61,10 @@ Visit https://dashboard.heroku.com/apps/torchbox-com-production, click on "More"
   **The issue can temporarily be averted by asking the editor to hide the preview panel while making their changes**
 - If the problem persists, investigate the size of the image they are using.
 
+### 3. If a listing page has crashed because the image renditions have been re-created
+
+**Leave it for a while. The server will continue to recreate the renditions in the background. In five minutes it will probably have recovered.**
+
 Note that as part of mitigating this issue, we have run a script and all images in the bucket have been automatically resized if:
 
 - they have more than 10,000,000px

--- a/docs/support-runbook.md
+++ b/docs/support-runbook.md
@@ -31,10 +31,39 @@ See also our [incident process](https://intranet.torchbox.com/propositions/desig
 - [Heroku Production](https://dashboard.heroku.com/apps/torchbox-com-production)
 - [Heroku Staging](https://dashboard.heroku.com/apps/torchbox-com-staging)
 
+Note that the production site uses 1 professionals dyno rather than 2 standard dynos, in order to avoid memory issues due to image processing.
+
 ###Documentation
 
 - See [External documentation](/external-docs)
 
 ## Scenarios
 
-The build is a simple wagtail build, with no external integrations, and no donation flow. For now there are no obvious points of failure to document.
+The build is a simple wagtail build, with no external integrations, and no donation flow.
+
+## Scenario A: Server memory overload due to image processing
+
+During the build we have experienced memory issues on the server due to:
+
+- webp conversion of images
+- large numbers of image renditions on some pages, due to using `{% srcset_image %}` and `<picture>` tags.
+
+### 1. Has the whole server failed, or just one page that has run out of memory?
+
+**If the whole site is down, and papertrail reports "Memory quota vastly exceeded", the site can generally be restarted in heroku.**
+
+Visit https://dashboard.heroku.com/apps/torchbox-com-production, click on "More" and choose "Restart all dynos".
+
+### 2. If only one page has thrown an error (typically it can occur in the editor's preview, when new image-heavy pages are being created)
+
+- Usually it will recover
+- If an editor has raised this as a problem:
+  **The issue can temporarily be averted by asking the editor to hide the preview panel while making their changes**
+- If the problem persists, investigate the size of the image they are using.
+
+Note that as part of mitigating this issue, we have run a script and all images in the bucket have been automatically resized if:
+
+- they have more than 10,000,000px
+- they are larger than 2mb
+
+Also note that editors can no longer upload images that exceed these parameters

--- a/docs/support-runbook.md
+++ b/docs/support-runbook.md
@@ -1,0 +1,40 @@
+# Support runbook
+
+This document describes possible ways in which the system may fail or malfunction, with instructions how to handle and recover from these scenarios.
+
+This runbook is supplementary to the [general 24/7 support runbook](https://intranet.torchbox.com/propositions/design-and-build-proposition/delivering-projects/dedicated-support-team/247-support-out-of-hours-runbook/), with details about project-specific actions which may be necessary for troubleshooting and restoring service.
+
+See also our [incident process](https://intranet.torchbox.com/propositions/design-and-build-proposition/delivering-projects/application-support/incident-process/) if you're not already following this.
+
+## Support resources
+
+###Project resources
+
+- [Project repository](https://github.com/torchbox/torchbox.com)
+- [Monday.com project](https://torchbox.monday.com/boards/1192293412/)
+- [Production site](https://torchbox-com-production.torchbox.dev/)
+- [Staging site](https://torchbox-com-staging.torchbox.dev/)
+- Developers slack: `#torchbox-webiste-dev`
+- Editors ('client') slack: `#torchbox-website-editors`
+
+###Monitoring
+
+- [Papertrail production](https://my.papertrailapp.com/systems/torchbox-com-production/events)
+- [Papertrail staging](https://my.papertrailapp.com/systems/torchbox-com-staging/events)
+- [Sentry project](https://torchbox.sentry.io/projects/torchbox-website/?project=1221893)
+- [Scout APM](https://scoutapm.com/apps/371126)
+
+###Infrastructure
+
+- S3 bucket production: `buckup-torchbox-production-new` (Note that there is a ticket to change this post-launch)
+- S3 bucket staging: `buckup-torchbox-staging-new`
+- [Heroku Production](https://dashboard.heroku.com/apps/torchbox-com-production)
+- [Heroku Staging](https://dashboard.heroku.com/apps/torchbox-com-staging)
+
+###Documentation
+
+- See [External documentation](/external-docs)
+
+## Scenarios
+
+The build is a simple wagtail build, with no external integrations, and no donation flow. For now there are no obvious points of failure to document.

--- a/docs/support-runbook.md
+++ b/docs/support-runbook.md
@@ -14,7 +14,7 @@ See also our [incident process](https://intranet.torchbox.com/propositions/desig
 - [Monday.com project](https://torchbox.monday.com/boards/1192293412/)
 - [Production site](https://torchbox-com-production.torchbox.dev/)
 - [Staging site](https://torchbox-com-staging.torchbox.dev/)
-- Developers slack: `#torchbox-webiste-dev`
+- Developers slack: `#torchbox-website-dev`
 - Editors ('client') slack: `#torchbox-website-editors`
 
 ###Monitoring

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -86,3 +86,4 @@ nav:
   - 'Data import': 'data-import.md'
   - 'Upgrading guidelines': 'upgrading.md'
   - 'Hotjar tracking in wagtail admin': 'hotjar-tracking.md'
+  - 'Runbook': support-runbook.md


### PR DESCRIPTION
[Link to Ticket](https://torchbox.monday.com/boards/1435178786/pulses/1435178952)

### Description of Changes Made

Adds key information for the support team

### How to Test

In a local build, run `mkdocs serve' and visit http://0.0.0.0:8001/support-runbook/

### Screenshots

<details>
  <summary>Expand to see more</summary>

</details>

### MR Checklist

- [x] Add a description of your pull request and instructions for the reviewer to verify your work.
- [x] If your pull request is for a specific ticket, link to it in the description.
- [x] Stay on point and keep it small so the merge request can be easily reviewed.
- [x] Tests and linting passes.

#### Unit tests

- [ ] Added
- [x] Not required

#### Documentation

- [x] Updated build docs
- [ ] Updated editor guidelines (https://docs.google.com/document/d/1PAWccdQ4tfaZsrEWmpDhvP3GH5RRmBOARFVp4b-kje8/edit?usp=sharing)
- [ ] Not required

#### Browser testing

- [ ] I have tested in the following browsers and environments (edit the list as required)
  - Latest version of Chrome on mac
  - Latest version of Firefox on mac
  - Latest version of Safari on mac
  - Safari on last two versions of iOS
  - Chrome on last two versions of Android
- [x] Not required

#### Data protection

- [x] Not relevant
- [ ] This adds new sources of PII and documents it and modifies Birdbath processors accordingly

#### Accessibility

- [ ] Automated WCAG 2.1 tests pass
- [ ] HTML validation passes
- [ ] Manual WCAG 2.1 tests completed
- [ ] I have tested in a screen reader
- [ ] I have tested in high-contrast mode
- [ ] Any animations removed for prefers-reduced-motion
- [x] Not required

#### Sustainability

- [ ] Images are optimised and lazy-loading used where appropriate
- [ ] SVGs have been optimised
- [ ] Perfomance and transfer of data considered
- [ ] If JavaScript is needed alternatives have been considered
- [x] Not required

#### Pattern library

- [ ] The pattern library component for this template displays correctly, and does not break parent templates
- [ ] The styleguide is updated if relevant
- [x] Changes are not relevant the pattern library
