### PR TITLE
Partner logo retina rendition

### DIFF
--- a/tbx/project_styleguide/templates/patterns/molecules/partner_logos/partner_logos.html
+++ b/tbx/project_styleguide/templates/patterns/molecules/partner_logos/partner_logos.html
@@ -3,7 +3,13 @@
 <div class="partners__logos {% if classes %}{{ classes }}{% endif %}">
     {% for partner_logo in partner_logos %}
         <div class="partners__logo-wrapper">
-            {% image partner_logo max-100x90 format-webp loading="lazy" class="partners__logo" %}
+            {% image partner_logo max-100x90 format-webp as partner_logo_image %}
+            {% image partner_logo max-200x180 format-webp as partner_logo_image_retina %}
+
+            <picture class="partners__logo-picture">
+                <source srcset="{{ partner_logo_image.url }} 1x, {{ partner_logo_image_retina.url }} 2x" />
+                <img src="{{ partner_logo_image.url }}" alt="{{ partner_logo_image.alt }}" class="partners__logo" />
+            </picture>
         </div>
     {% endfor %}
 </div>

--- a/tbx/project_styleguide/templates/patterns/molecules/partner_logos/partner_logos.yaml
+++ b/tbx/project_styleguide/templates/patterns/molecules/partner_logos/partner_logos.yaml
@@ -7,6 +7,11 @@ context:
 
 tags:
   image:
-    partner_logo max-100x90 format-webp loading="lazy" class="partners__logo":
-      raw: |
-        <img src="https://picsum.photos/100/90.webp" width="100" height="90" alt="" class="partners__logo">
+    partner_logo max-100x90 format-webp as partner_logo_image:
+      target_var: partner_logo_image
+      raw:
+        url: 'https://picsum.photos/100/90.webp'
+    partner_logo max-200x180 format-webp as partner_logo_image_retina:
+      target_var: partner_logo_image_retina
+      raw:
+        url: 'https://picsum.photos/200/180.webp'

--- a/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/partners_block.yaml
+++ b/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/partners_block.yaml
@@ -9,6 +9,11 @@ context:
 
 tags:
   image:
-    partner_logo max-100x90 format-webp loading="lazy" class="partners__logo":
-      raw: |
-        <img src="https://picsum.photos/100/90.webp" width="100" height="90" alt="" class="partners__logo">
+    partner_logo max-100x90 format-webp as partner_logo_image:
+      target_var: partner_logo_image
+      raw:
+        url: 'https://picsum.photos/100/90.webp'
+    partner_logo max-200x180 format-webp as partner_logo_image_retina:
+      target_var: partner_logo_image_retina
+      raw:
+        url: 'https://picsum.photos/200/180.webp'

--- a/tbx/project_styleguide/templates/patterns/pages/home/home_page.yaml
+++ b/tbx/project_styleguide/templates/patterns/pages/home/home_page.yaml
@@ -15,6 +15,11 @@ tags:
     '':
       template_name: 'patterns/navigation/components/footer-links.html'
   image:
-    partner_logo max-100x90 format-webp loading="lazy" class="partners__logo":
-      raw: |
-        <img src="https://picsum.photos/100/90.webp" width="100" height="90" alt="" class="partners__logo">
+    partner_logo max-100x90 format-webp as partner_logo_image:
+      target_var: partner_logo_image
+      raw:
+        url: 'https://picsum.photos/100/90.webp'
+    partner_logo max-200x180 format-webp as partner_logo_image_retina:
+      target_var: partner_logo_image_retina
+      raw:
+        url: 'https://picsum.photos/200/180.webp'

--- a/tbx/project_styleguide/templates/patterns/styleguide/components/components.yaml
+++ b/tbx/project_styleguide/templates/patterns/styleguide/components/components.yaml
@@ -164,9 +164,14 @@ tags:
       raw: |
         <img src="https://picsum.photos/110/70.webp" width="110" height="70" alt="Some alt" class="featured-case-study__company-logo">
     # for partners
-    partner_logo max-100x90 format-webp loading="lazy" class="partners__logo":
-      raw: |
-        <img src="https://picsum.photos/100/90.webp" width="100" height="90" alt="" class="partners__logo">
+    partner_logo max-100x90 format-webp as partner_logo_image:
+      target_var: partner_logo_image
+      raw:
+        url: 'https://picsum.photos/100/90.webp'
+    partner_logo max-200x180 format-webp as partner_logo_image_retina:
+      target_var: partner_logo_image_retina
+      raw:
+        url: 'https://picsum.photos/200/180.webp'
     # event block
     value.image fill-525x510 format-webp as desktop_image:
       target_var: desktop_image

--- a/tbx/static_src/sass/components/_partners.scss
+++ b/tbx/static_src/sass/components/_partners.scss
@@ -3,11 +3,19 @@
 .partners {
     $root: &;
 
+    @mixin partner-logo-sizes() {
+        width: 100%;
+        height: 100%;
+        max-width: 100px;
+        max-height: 90px;
+    }
+
     &__logos {
         display: flex;
         flex-wrap: wrap;
         gap: $spacer-mini;
         justify-content: center;
+        align-items: center;
 
         @include media-query(large) {
             justify-content: flex-start;
@@ -38,19 +46,22 @@
 
         #{$root}__logos--wide & {
             @include media-query('x-large') {
-                width: auto;
-                height: auto;
+                @include partner-logo-sizes();
             }
         }
     }
 
     &__logo {
+        @include partner-logo-sizes();
         filter: grayscale(1) invert(1) brightness(1.5);
-        width: auto;
-        height: auto;
+        object-fit: contain;
 
         @include high-contrast-light-mode() {
             filter: none;
         }
+    }
+
+    &__logo-picture {
+        @include partner-logo-sizes();
     }
 }


### PR DESCRIPTION
No ticket for this one

### Description of Changes Made

- Adds a retina version of the partner logo so it appears less pixelated on those screens
- Removes 'loading="lazy"' from the image as they're being used above the fold

### How to Test

Easiest way is to compare staging/production against your local build with matching images. 

### Screenshots

Desktop & Mobile before/after in the details element. You can see the main differences in the Islamic Relief, Action for Children and Samaritans logos. I think others such as Breast Cancer Now are using low res images to start with.

<details>
  <summary>Expand to see more</summary>

<img width="1438" alt="Screenshot 2024-05-01 at 10 16 40" src="https://github.com/torchbox/torchbox.com/assets/31627284/5b843e71-1540-4e82-8e04-f38e14390d00">

<img width="1440" alt="Screenshot 2024-05-01 at 10 16 45" src="https://github.com/torchbox/torchbox.com/assets/31627284/e7c893ae-b681-4b83-b772-3e994b636f1e">

![Screenshot_20240501-102549](https://github.com/torchbox/torchbox.com/assets/31627284/2d8e6925-2bf5-4158-a1e2-34e0ce3a3435)

![Screenshot_20240501-103725](https://github.com/torchbox/torchbox.com/assets/31627284/adbaeab4-b625-4483-be87-646e2c5a14d9)


</details>

### MR Checklist


- [x] Add a description of your pull request and instructions for the reviewer to verify your work.
- [x] If your pull request is for a specific ticket, link to it in the description.
- [x] Stay on point and keep it small so the merge request can be easily reviewed.
- [x] Tests and linting passes.

#### Unit tests

- [ ] Added
- [x] Not required

#### Documentation

- [ ] Updated build docs
- [ ] Updated editor guidelines (https://docs.google.com/document/d/1PAWccdQ4tfaZsrEWmpDhvP3GH5RRmBOARFVp4b-kje8/edit?usp=sharing)
- [x] Not required

#### Browser testing

- [x] I have tested in the following browsers and environments (edit the list as required)
  - Latest version of Chrome on mac
  - Latest version of Firefox on mac
  - Latest version of Safari on mac
  - Safari on last two versions of iOS
  - Chrome on last two versions of Android
- [ ] Not required

#### Data protection

- [x] Not relevant
- [ ] This adds new sources of PII and documents it and modifies Birdbath processors accordingly

#### Accessibility

- [ ] Automated WCAG 2.1 tests pass
- [ ] HTML validation passes
- [ ] Manual WCAG 2.1 tests completed
- [ ] I have tested in a screen reader
- [ ] I have tested in high-contrast mode
- [ ] Any animations removed for prefers-reduced-motion
- [ ] Not required

#### Sustainability

- [ ] Images are optimised and lazy-loading used where appropriate
- [ ] SVGs have been optimised
- [ ] Perfomance and transfer of data considered
- [ ] If JavaScript is needed alternatives have been considered
- [ ] Not required

#### Pattern library

- [x] The pattern library component for this template displays correctly, and does not break parent templates
- [ ] The styleguide is updated if relevant
- [ ] Changes are not relevant the pattern library
