### PR TITLE
Lazy load partner logos

### DIFF
--- a/tbx/core/models.py
+++ b/tbx/core/models.py
@@ -161,6 +161,11 @@ class HomePage(ColourThemeMixin, ContactMixin, SocialFields, NavigationFields, P
         ]
     )
 
+    def get_context(self, request):
+        context = super().get_context(request)
+        context['is_home_page'] = True
+        return context
+
 
 # Standard page
 class StandardPage(

--- a/tbx/core/models.py
+++ b/tbx/core/models.py
@@ -163,7 +163,7 @@ class HomePage(ColourThemeMixin, ContactMixin, SocialFields, NavigationFields, P
 
     def get_context(self, request):
         context = super().get_context(request)
-        context['is_home_page'] = True
+        context["is_home_page"] = True
         return context
 
 

--- a/tbx/project_styleguide/templates/patterns/molecules/partner_logos/partner_logos.html
+++ b/tbx/project_styleguide/templates/patterns/molecules/partner_logos/partner_logos.html
@@ -8,7 +8,7 @@
 
             <picture class="partners__logo-picture">
                 <source srcset="{{ partner_logo_image.url }} 1x, {{ partner_logo_image_retina.url }} 2x" />
-                <img src="{{ partner_logo_image.url }}" alt="{{ partner_logo_image.alt }}" class="partners__logo" />
+                <img src="{{ partner_logo_image.url }}" alt="{{ partner_logo_image.alt }}" class="partners__logo" {% if not is_home_page %}loading="lazy"{% endif %} />
             </picture>
         </div>
     {% endfor %}


### PR DESCRIPTION
No ticket for this, it came out of a discussion here: https://github.com/torchbox/torchbox.com/pull/248#discussion_r1586135256

### Description of Changes Made

Lazy loads the partner logo images but not when they're used on the homepage as they appear above the fold.

### How to Test

Check the homepage to make sure the partner logos don't have the `loading="lazy"` attribute but they do when used as a streamfield.

### Screenshots

<details>
  <summary>Expand to see more</summary>

</details>

### MR Checklist

- [x] Add a description of your pull request and instructions for the reviewer to verify your work.
- [x] If your pull request is for a specific ticket, link to it in the description.
- [x] Stay on point and keep it small so the merge request can be easily reviewed.
- [x] Tests and linting passes.

#### Unit tests

- [ ] Added
- [x] Not required

#### Documentation

- [ ] Updated build docs
- [ ] Updated editor guidelines (https://docs.google.com/document/d/1PAWccdQ4tfaZsrEWmpDhvP3GH5RRmBOARFVp4b-kje8/edit?usp=sharing)
- [x] Not required

#### Browser testing

- [x] I have tested in the following browsers and environments (edit the list as required)
  - Latest version of Chrome on mac
  - Latest version of Firefox on mac
  - Latest version of Safari on mac
  - Safari on last two versions of iOS
  - Chrome on last two versions of Android
- [ ] Not required

#### Data protection

- [x] Not relevant
- [ ] This adds new sources of PII and documents it and modifies Birdbath processors accordingly

#### Accessibility

- [ ] Automated WCAG 2.1 tests pass
- [ ] HTML validation passes
- [ ] Manual WCAG 2.1 tests completed
- [ ] I have tested in a screen reader
- [ ] I have tested in high-contrast mode
- [ ] Any animations removed for prefers-reduced-motion
- [x] Not required

#### Sustainability

- [ ] Images are optimised and lazy-loading used where appropriate
- [ ] SVGs have been optimised
- [ ] Perfomance and transfer of data considered
- [ ] If JavaScript is needed alternatives have been considered
- [x] Not required

#### Pattern library

- [ ] The pattern library component for this template displays correctly, and does not break parent templates
- [ ] The styleguide is updated if relevant
- [x] Changes are not relevant the pattern library
