### PR TITLE
Ensure the work chooser block preserves selected page order

### DIFF
--- a/tbx/core/blocks.py
+++ b/tbx/core/blocks.py
@@ -466,7 +466,9 @@ class WorkChooserBlock(blocks.StructBlock):
             .in_bulk()
         )
         # Keeps the ordering the same as in values.
-        context["work_pages"] = [work_pages.get(_id) for _id in work_page_ids]
+        context["work_pages"] = [
+            work_pages[_id] for _id in work_page_ids if _id in work_pages
+        ]
         return context
 
     class Meta:

--- a/tbx/core/blocks.py
+++ b/tbx/core/blocks.py
@@ -454,14 +454,19 @@ class WorkChooserBlock(blocks.StructBlock):
                 "fill-740x670|format-webp",
             ),
         )
-        context["work_pages"] = (
-            Page.objects.filter(pk__in=[page.pk for page in value["work_pages"]])
+
+        work_page_ids = [page.pk for page in value["work_pages"]]
+        work_pages = (
+            Page.objects.filter(pk__in=work_page_ids)
             .live()
             .public()
             .defer_streamfields()
             .prefetch_related(prefetch_listing_images)
             .specific()
+            .in_bulk()
         )
+        # Keeps the ordering the same as in values.
+        context["work_pages"] = [work_pages.get(_id) for _id in work_page_ids]
         return context
 
     class Meta:

--- a/tbx/core/tests/test_blocks.py
+++ b/tbx/core/tests/test_blocks.py
@@ -1,0 +1,28 @@
+from django.test import TestCase
+
+from tbx.core.blocks import WorkChooserBlock
+from tbx.work.factories import WorkPageFactory
+
+
+class WorkChooserBlockTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.pages = WorkPageFactory.create_batch(3)
+
+    def test_block_context(self):
+        block = WorkChooserBlock()
+
+        context = block.get_context(
+            {"featured_work_heading": "Featured Work", "work_pages": self.pages}
+        )
+        self.assertListEqual(context["work_pages"], self.pages)
+
+        context = block.get_context(
+            {
+                "featured_work_heading": "Featured Work",
+                "work_pages": [self.pages[2], self.pages[1], self.pages[0]],
+            }
+        )
+        self.assertListEqual(
+            context["work_pages"], [self.pages[2], self.pages[1], self.pages[0]]
+        )

--- a/tbx/core/tests/test_blocks.py
+++ b/tbx/core/tests/test_blocks.py
@@ -26,3 +26,12 @@ class WorkChooserBlockTest(TestCase):
         self.assertListEqual(
             context["work_pages"], [self.pages[2], self.pages[1], self.pages[0]]
         )
+
+    def test_block_context_with_unpublished_pages(self):
+        block = WorkChooserBlock()
+        self.pages[0].unpublish()
+
+        context = block.get_context(
+            {"featured_work_heading": "Featured Work", "work_pages": self.pages}
+        )
+        self.assertListEqual(context["work_pages"], [self.pages[1], self.pages[2]])


### PR DESCRIPTION
Follow up to #251

### Description of Changes Made

Fixes an issue where the chosen work pages in the work chooser block would lose their order

### How to Test

Add a work block with several pages. They should show in the chosen order

### Screenshots

<details>
  <summary>Expand to see more</summary>

</details>

### MR Checklist

- [x] Add a description of your pull request and instructions for the reviewer to verify your work.
- [ ] If your pull request is for a specific ticket, link to it in the description.
- [x] Stay on point and keep it small so the merge request can be easily reviewed.
- [x] Tests and linting passes.

#### Unit tests

- [x] Added
- [ ] Not required

#### Documentation

- [ ] Updated build docs
- [ ] Updated editor guidelines (https://docs.google.com/document/d/1PAWccdQ4tfaZsrEWmpDhvP3GH5RRmBOARFVp4b-kje8/edit?usp=sharing)
- [ ] Updated field spec (https://docs.google.com/spreadsheets/d/1v1yqcSC54Vag4mxmTp8e6ZrnxITqzbjCA4A9XPQdXk8/edit?usp=sharing)
- [x] Not required

#### Browser testing

- [ ] I have tested in the following browsers and environments (edit the list as required)
  - Latest version of Chrome on mac
  - Latest version of Firefox on mac
  - Latest version of Safari on mac
  - Safari on last two versions of iOS
  - Chrome on last two versions of Android
- [x] Not required

#### Data protection

- [x] Not relevant
- [ ] This adds new sources of PII and documents it and modifies Birdbath processors accordingly

#### Accessibility

- [ ] Automated WCAG 2.1 tests pass
- [ ] HTML validation passes
- [ ] Manual WCAG 2.1 tests completed
- [ ] I have tested in a screen reader
- [ ] I have tested in high-contrast mode
- [ ] Any animations removed for prefers-reduced-motion
- [x] Not required

#### Sustainability

- [ ] Images are optimised and lazy-loading used where appropriate
- [ ] SVGs have been optimised
- [ ] Perfomance and transfer of data considered
- [ ] If JavaScript is needed alternatives have been considered
- [x] Not required

#### Pattern library

- [ ] The pattern library component for this template displays correctly, and does not break parent templates
- [ ] The styleguide is updated if relevant
- [x] Changes are not relevant the pattern library
