### PR TITLE
Bump gunicorn to ^22.0.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1002,22 +1002,23 @@ dev = ["flake8", "markdown", "twine", "wheel"]
 
 [[package]]
 name = "gunicorn"
-version = "20.1.0"
+version = "22.0.0"
 description = "WSGI HTTP Server for UNIX"
 optional = true
-python-versions = ">=3.5"
+python-versions = ">=3.7"
 files = [
-    {file = "gunicorn-20.1.0-py3-none-any.whl", hash = "sha256:9dcc4547dbb1cb284accfb15ab5667a0e5d1881cc443e0677b4882a4067a807e"},
-    {file = "gunicorn-20.1.0.tar.gz", hash = "sha256:e0a968b5ba15f8a328fdfd7ab1fcb5af4470c28aaf7e55df02a99bc13138e6e8"},
+    {file = "gunicorn-22.0.0-py3-none-any.whl", hash = "sha256:350679f91b24062c86e386e198a15438d53a7a8207235a78ba1b53df4c4378d9"},
+    {file = "gunicorn-22.0.0.tar.gz", hash = "sha256:4a0b436239ff76fb33f11c07a16482c521a7e09c1ce3cc293c2330afe01bec63"},
 ]
 
 [package.dependencies]
-setuptools = ">=3.0"
+packaging = "*"
 
 [package.extras]
-eventlet = ["eventlet (>=0.24.1)"]
+eventlet = ["eventlet (>=0.24.1,!=0.36.0)"]
 gevent = ["gevent (>=1.4.0)"]
 setproctitle = ["setproctitle"]
+testing = ["coverage", "eventlet", "gevent", "pytest", "pytest-cov"]
 tornado = ["tornado (>=0.2)"]
 
 [[package]]
@@ -2733,4 +2734,4 @@ gunicorn = ["gunicorn"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "1d9bb5ef86c3324adaab8ae9777f5b6e7ea5739154cb9157a304baa2339aa610"
+content-hash = "668386b306cba7a12e7855bf5f17306adc4935524be0d9bb644d5f8667c8f172"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ python = "^3.11"
 Django = "~4.2"
 wagtail = "~6.0"
 psycopg2 = "^2.9.9"
-gunicorn = { version = "^20.1.0", optional = true }
+gunicorn = {version = "^22.0.0", optional = true}
 whitenoise = "^6.1.0"
 phonenumbers = "^8.12.48"
 Wand = "^0.6.10"


### PR DESCRIPTION
This bumps the locked version of gunicorn to 22.0.0 which fixes a number of security vulnerabilities.