### PR TITLE
Tidy up js as per feedback for the same code on kit

### DIFF
--- a/tbx/static_src/javascript/components/table-hint.js
+++ b/tbx/static_src/javascript/components/table-hint.js
@@ -22,25 +22,17 @@ class TableHint {
             }
         });
 
+        // Check if the user prefers reduced motion - only use smooth scroll if they don't
         const isReduced =
-            window.matchMedia(`(prefers-reduced-motion: reduce)`) === true ||
-            window.matchMedia(`(prefers-reduced-motion: reduce)`).matches ===
-                true;
+            window.matchMedia('(prefers-reduced-motion: reduce)').matches ===
+            true;
 
         this.button.addEventListener('click', () => {
-            if (isReduced) {
-                this.node.scroll({
-                    top: 0,
-                    left: 500,
-                    behavior: 'auto',
-                });
-            } else {
-                this.node.scroll({
-                    top: 0,
-                    left: 500,
-                    behavior: 'smooth',
-                });
-            }
+            this.node.scroll({
+                top: 0,
+                left: 500,
+                behavior: isReduced ? 'auto' : 'smooth',
+            });
         });
     }
 }


### PR DESCRIPTION
No ticket

### Description of Changes Made

See Chris' feedback on https://git.torchbox.com/internal/wagtail-kit/-/merge_requests/901

### How to Test

Ensure that if 'prefers-reduced-motion' is set the 'see more' button on tables at mobile scrolls instantly rather than smoothly.

### Screenshots

<details>
  <summary>Expand to see more</summary>

</details>

### MR Checklist

- [x] Add a description of your pull request and instructions for the reviewer to verify your work.
- [x] If your pull request is for a specific ticket, link to it in the description.
- [x] Stay on point and keep it small so the merge request can be easily reviewed.
- [x] Tests and linting passes.

#### Unit tests

- [ ] Added
- [x] Not required

#### Documentation

- [ ] Updated build docs
- [ ] Updated editor guidelines (https://docs.google.com/document/d/1PAWccdQ4tfaZsrEWmpDhvP3GH5RRmBOARFVp4b-kje8/edit?usp=sharing)
- [ ] Updated field spec (https://docs.google.com/spreadsheets/d/1v1yqcSC54Vag4mxmTp8e6ZrnxITqzbjCA4A9XPQdXk8/edit?usp=sharing)
- [x] Not required

#### Browser testing

- [x] I have tested in the following browsers and environments (edit the list as required)
  - Latest version of Chrome on mac
- [ ] Not required

#### Data protection

- [x] Not relevant
- [ ] This adds new sources of PII and documents it and modifies Birdbath processors accordingly

#### Accessibility

- [ ] Automated WCAG 2.1 tests pass
- [ ] HTML validation passes
- [ ] Manual WCAG 2.1 tests completed
- [ ] I have tested in a screen reader
- [ ] I have tested in high-contrast mode
- [x] Any animations removed for prefers-reduced-motion
- [ ] Not required

#### Sustainability

- [ ] Images are optimised and lazy-loading used where appropriate
- [ ] SVGs have been optimised
- [ ] Perfomance and transfer of data considered
- [ ] If JavaScript is needed alternatives have been considered
- [x] Not required

#### Pattern library

- [ ] The pattern library component for this template displays correctly, and does not break parent templates
- [ ] The styleguide is updated if relevant
- [x] Changes are not relevant the pattern library
