### PR TITLE
Attempt to resolve a google issue where the first letter is omitted from motif headings in search results

### DIFF
--- a/docs/front-end/motif-headings.md
+++ b/docs/front-end/motif-headings.md
@@ -5,3 +5,5 @@ The site makes use of coloured drop-cap letters in major headings, with an optio
 Because some letters are narrower than others, there was an issue with a large gap after the initial drop-cap, as well as an issue with the letter I where it was too narrow to see the final background flame image. This has been solved with some custom classes for particular letters.
 
 See the `motif-heading.html` component (under `atoms` in the styleguide) and the equivalent `motif-heading.scss` sass file.
+
+There has been an issue with google displaying the heading one without the first letter in search results, probably because of the transparent styling on the first letter. As an attempt to resolve this, for h1s, we now move the motif heading into a paragraph tag, with a visually hidden h1 tag.

--- a/tbx/core/templatetags/util_tags.py
+++ b/tbx/core/templatetags/util_tags.py
@@ -78,3 +78,10 @@ def format_date_for_event(start_date, start_time=None, end_date=None, end_time=N
                     f", {format_time(end_time)}{end_time.strftime('%p').lower()}"
                 )
     return formatted_start_date
+
+
+@register.filter(name='ifinlist')
+def ifinlist(value, list):
+    # cast to strings before testing as this is used for heading levels 2, 3, 4 etc
+    stringList = [str(x) for x in list]
+    return str(value) in stringList

--- a/tbx/core/templatetags/util_tags.py
+++ b/tbx/core/templatetags/util_tags.py
@@ -78,10 +78,3 @@ def format_date_for_event(start_date, start_time=None, end_date=None, end_time=N
                     f", {format_time(end_time)}{end_time.strftime('%p').lower()}"
                 )
     return formatted_start_date
-
-
-@register.filter(name="ifinlist")
-def ifinlist(value, list):
-    # cast to strings before testing as this is used for heading levels 2, 3, 4 etc
-    stringList = [str(x) for x in list]
-    return str(value) in stringList

--- a/tbx/core/templatetags/util_tags.py
+++ b/tbx/core/templatetags/util_tags.py
@@ -80,7 +80,7 @@ def format_date_for_event(start_date, start_time=None, end_date=None, end_time=N
     return formatted_start_date
 
 
-@register.filter(name='ifinlist')
+@register.filter(name="ifinlist")
 def ifinlist(value, list):
     # cast to strings before testing as this is used for heading levels 2, 3, 4 etc
     stringList = [str(x) for x in list]

--- a/tbx/core/templatetags/util_tags.py
+++ b/tbx/core/templatetags/util_tags.py
@@ -78,3 +78,10 @@ def format_date_for_event(start_date, start_time=None, end_date=None, end_time=N
                     f", {format_time(end_time)}{end_time.strftime('%p').lower()}"
                 )
     return formatted_start_date
+
+
+@register.filter(name="ifinlist")
+def ifinlist(value, list):
+    # cast to strings before testing as this is used for heading levels 2, 3, 4 etc
+    stringList = [str(x) for x in list]
+    return str(value) in stringList

--- a/tbx/project_styleguide/templates/patterns/atoms/motif-heading/motif-heading.html
+++ b/tbx/project_styleguide/templates/patterns/atoms/motif-heading/motif-heading.html
@@ -1,6 +1,6 @@
 {% load util_tags %}
 
-{% if heading_level|ifinlist:"2,3,4,5,6" %}
+{% if heading_level > '1' and heading_level < '7' %}
     {# If the heading level is anything other than one, output the heading tag with the motif styles #}
     <h{{ heading_level|default:1 }} class="motif-heading {% if classes %}{{ classes }}{% endif %}" aria-label="{% firstof aria_label heading %}">
 {% else %}
@@ -19,7 +19,7 @@
     <span class="motif-heading__drop-cap {% if first_letter|lower == 'i' %}motif-heading__drop-cap--i{% endif %} {% if first_letter|lower in 'f,p' %}motif-heading__drop-cap--narrow{% endif %} {% if first_letter|lower == 'w' %}motif-heading__drop-cap--narrower{% endif %} {% if first_letter|lower in 't,y' %}motif-heading__drop-cap--narrowest{% endif %}">{{ first_letter }}</span><span>{{ heading|slice:"1:" }}</span>
 {% endwith %}
 
-{% if heading_level|ifinlist:"2,3,4,5,6" %}
+{% if heading_level > '1' and heading_level < '7' %}
     </h{{ heading_level|default:1 }}>
 {% else %}
     </p>

--- a/tbx/project_styleguide/templates/patterns/atoms/motif-heading/motif-heading.html
+++ b/tbx/project_styleguide/templates/patterns/atoms/motif-heading/motif-heading.html
@@ -1,4 +1,5 @@
-{% if heading_level > '1' and heading_level < '7' %}
+{% load util_tags %}
+{% if heading_level|ifinlist:'2,3,4,5,6' %}
     {# If the heading level is anything other than one, output the heading tag with the motif styles #}
     <h{{ heading_level|default:1 }} class="motif-heading {% if classes %}{{ classes }}{% endif %}" aria-label="{% firstof aria_label heading %}">
 {% else %}
@@ -10,14 +11,14 @@
     because of the `color:transparent` CSS on the initial cap.
     {% endcomment %}
     <h{{ heading_level|default:1 }} class="sr-only">{{ heading }}</h{{ heading_level|default:1 }}>
-    <p aria-hidden="true" class="motif-heading {% if classes %}{{ classes }}{% endif %}" aria-label="{% firstof aria_label heading %}">
+    <p aria-hidden="true" class="motif-heading {% if classes %}{{ classes }}{% endif %}">
 {% endif %}
 
 {% with first_letter=heading|slice:":1" %}
     <span class="motif-heading__drop-cap {% if first_letter|lower == 'i' %}motif-heading__drop-cap--i{% endif %} {% if first_letter|lower in 'f,p' %}motif-heading__drop-cap--narrow{% endif %} {% if first_letter|lower == 'w' %}motif-heading__drop-cap--narrower{% endif %} {% if first_letter|lower in 't,y' %}motif-heading__drop-cap--narrowest{% endif %}">{{ first_letter }}</span><span>{{ heading|slice:"1:" }}</span>
 {% endwith %}
 
-{% if heading_level > '1' and heading_level < '7' %}
+{% if heading_level|ifinlist:'2,3,4,5,6' %}
     </h{{ heading_level|default:1 }}>
 {% else %}
     </p>

--- a/tbx/project_styleguide/templates/patterns/atoms/motif-heading/motif-heading.html
+++ b/tbx/project_styleguide/templates/patterns/atoms/motif-heading/motif-heading.html
@@ -1,5 +1,3 @@
-{% load util_tags %}
-
 {% if heading_level > '1' and heading_level < '7' %}
     {# If the heading level is anything other than one, output the heading tag with the motif styles #}
     <h{{ heading_level|default:1 }} class="motif-heading {% if classes %}{{ classes }}{% endif %}" aria-label="{% firstof aria_label heading %}">

--- a/tbx/project_styleguide/templates/patterns/atoms/motif-heading/motif-heading.html
+++ b/tbx/project_styleguide/templates/patterns/atoms/motif-heading/motif-heading.html
@@ -1,5 +1,26 @@
-<h{{ heading_level|default:1 }} class="motif-heading {% if classes %}{{ classes }}{% endif %}" aria-label="{% firstof aria_label heading %}">
-    {% with first_letter=heading|slice:":1" %}
-        <span class="motif-heading__drop-cap {% if first_letter|lower == 'i' %}motif-heading__drop-cap--i{% endif %} {% if first_letter|lower in 'f,p' %}motif-heading__drop-cap--narrow{% endif %} {% if first_letter|lower == 'w' %}motif-heading__drop-cap--narrower{% endif %} {% if first_letter|lower in 't,y' %}motif-heading__drop-cap--narrowest{% endif %}">{{ first_letter }}</span><span>{{ heading|slice:"1:" }}</span>
-    {% endwith %}
-</h{{ heading_level|default:1 }}>
+{% load util_tags %}
+
+{% if heading_level|ifinlist:"2,3,4,5,6" %}
+    {# If the heading level is anything other than one, output the heading tag with the motif styles #}
+    <h{{ heading_level|default:1 }} class="motif-heading {% if classes %}{{ classes }}{% endif %}" aria-label="{% firstof aria_label heading %}">
+{% else %}
+    {% comment %}
+    If the heading level is 1 (this is also the default which is an empty string),
+    output the h1 tag with a visually hidden style, then output a paragraph tag
+    with the motif heading styles. This is to mitigate an issue where google
+    was showing the motif headings without the first letter in search results, probably
+    because of the `color:transparent` CSS on the initial cap.
+    {% endcomment %}
+    <h{{ heading_level|default:1 }} class="sr-only">{{ heading }}</h{{ heading_level|default:1 }}>
+    <p aria-hidden="true" class="motif-heading {% if classes %}{{ classes }}{% endif %}" aria-label="{% firstof aria_label heading %}">
+{% endif %}
+
+{% with first_letter=heading|slice:":1" %}
+    <span class="motif-heading__drop-cap {% if first_letter|lower == 'i' %}motif-heading__drop-cap--i{% endif %} {% if first_letter|lower in 'f,p' %}motif-heading__drop-cap--narrow{% endif %} {% if first_letter|lower == 'w' %}motif-heading__drop-cap--narrower{% endif %} {% if first_letter|lower in 't,y' %}motif-heading__drop-cap--narrowest{% endif %}">{{ first_letter }}</span><span>{{ heading|slice:"1:" }}</span>
+{% endwith %}
+
+{% if heading_level|ifinlist:"2,3,4,5,6" %}
+    </h{{ heading_level|default:1 }}>
+{% else %}
+    </p>
+{% endif %}

--- a/tbx/project_styleguide/templates/patterns/molecules/home-page-hero/home-page-hero.html
+++ b/tbx/project_styleguide/templates/patterns/molecules/home-page-hero/home-page-hero.html
@@ -1,5 +1,5 @@
 <div class="grid__title home-page-hero">
-    {% include "patterns/atoms/motif-heading/motif-heading.html" with heading=page.title classes="motif-heading--one-c home-page-hero__title" heading_level=1 %}
+    {% include "patterns/atoms/motif-heading/motif-heading.html" with heading=page.title classes="motif-heading--one-c home-page-hero__title" %}
 
     <div class="employee-owned-icon home-page-hero__icon">
         {% include "patterns/atoms/icons/icon.html" with name="employee-owned-text" classname="employee-owned-icon__text-icon" %}

--- a/tbx/project_styleguide/templates/patterns/molecules/home-page-hero/home-page-hero.html
+++ b/tbx/project_styleguide/templates/patterns/molecules/home-page-hero/home-page-hero.html
@@ -1,5 +1,5 @@
 <div class="grid__title home-page-hero">
-    {% include "patterns/atoms/motif-heading/motif-heading.html" with heading=page.title classes="motif-heading--one-c home-page-hero__title" %}
+    {% include "patterns/atoms/motif-heading/motif-heading.html" with heading=page.title classes="motif-heading--one-c home-page-hero__title" heading_level=1 %}
 
     <div class="employee-owned-icon home-page-hero__icon">
         {% include "patterns/atoms/icons/icon.html" with name="employee-owned-text" classname="employee-owned-icon__text-icon" %}

--- a/tbx/static_src/sass/components/_motif-heading.scss
+++ b/tbx/static_src/sass/components/_motif-heading.scss
@@ -12,7 +12,6 @@
         background-color: var(--color--heading);
         background-repeat: no-repeat;
         background-size: 100%;
-        -webkit-text-fill-color: transparent;
         animation: motifAnimation 1.7s cubic-bezier(0.3, 0, 0.6, 1);
         background-origin: border-box;
         text-transform: uppercase;


### PR DESCRIPTION
[Link to Ticket](https://torchbox.monday.com/boards/1192293412/pulses/1527652921)

### Description of Changes Made

- Move the actual heading 1 to a visually hidden h1 tag
- Put the motif heading 1 into a paragraph tag hidden from screen readers
- Leave other headings with the same markup as previously
- Remove an extra unnecessary vendor prefix from the styles


### How to Test

View the home page and check the heading one and heading two styles display correctly.
Ensure that the heading one text is output twice, with both a h1 and a p tag. The h1 tag should be visible to screen readers, and the p tag should have the motif styles and be hidden from screen readers.

### Screenshots

<details>
  <summary>Expand to see more</summary>

Home page heading one showing markup in the inspector

![Screenshot 2024-06-10 at 11 00 28](https://github.com/torchbox/torchbox.com/assets/771869/14adebb1-bea5-476b-b7b1-55a22ec4d002)

Home page heading two showing markup in the inspector
![Screenshot 2024-06-10 at 11 01 05](https://github.com/torchbox/torchbox.com/assets/771869/7508a214-cb63-4497-acc6-9065b035b633)

</details>

### MR Checklist

- [x] Add a description of your pull request and instructions for the reviewer to verify your work.
- [x] If your pull request is for a specific ticket, link to it in the description.
- [x] Stay on point and keep it small so the merge request can be easily reviewed.
- [x] Tests and linting passes.

#### Unit tests

- [ ] Added
- [x] Not required

#### Documentation

- [x] Updated build docs
- [ ] Updated editor guidelines (https://docs.google.com/document/d/1PAWccdQ4tfaZsrEWmpDhvP3GH5RRmBOARFVp4b-kje8/edit?usp=sharing)
- [ ] Updated field spec (https://docs.google.com/spreadsheets/d/1v1yqcSC54Vag4mxmTp8e6ZrnxITqzbjCA4A9XPQdXk8/edit?usp=sharing)
- [ ] Not required

#### Browser testing

- [x] I have tested in the following browsers and environments (edit the list as required)
  - Latest version of Chrome on mac
  - Latest version of Firefox on mac
  - Latest version of Safari on mac
  - Safari on last two versions of iOS
  - Chrome on last two versions of Android
- [ ] Not required

#### Data protection

- [x] Not relevant
- [ ] This adds new sources of PII and documents it and modifies Birdbath processors accordingly

#### Accessibility

- [x] Automated WCAG 2.1 tests pass
- [x] HTML validation passes
- [ ] Manual WCAG 2.1 tests completed
- [x] I have tested in a screen reader
- [ ] I have tested in high-contrast mode
- [ ] Any animations removed for prefers-reduced-motion
- [ ] Not required

#### Sustainability

- [ ] Images are optimised and lazy-loading used where appropriate
- [ ] SVGs have been optimised
- [ ] Perfomance and transfer of data considered
- [ ] If JavaScript is needed alternatives have been considered
- [x] Not required

#### Pattern library

- [ ] The pattern library component for this template displays correctly, and does not break parent templates
- [ ] The styleguide is updated if relevant
- [x] Changes are not relevant the pattern library
