### PR TITLE
Add an option for a document download to CTAs and Contact CTAs

### DIFF
--- a/tbx/core/blocks.py
+++ b/tbx/core/blocks.py
@@ -16,6 +16,7 @@ from wagtail.blocks.struct_block import StructBlockValidationError
 from wagtail.contrib.typed_table_block.blocks import (
     TypedTableBlock as WagtailTypedTableBlock,
 )
+from wagtail.documents.blocks import DocumentChooserBlock
 from wagtail.embeds.blocks import EmbedBlock as WagtailEmbedBlock
 from wagtail.embeds.embeds import get_embed
 from wagtail.embeds.exceptions import EmbedException
@@ -220,6 +221,8 @@ class ButtonLinkStructValue(blocks.StructValue):
             return block.value
         elif block_type == "email":
             return f"mailto:{block.value}"
+        elif block_type == "document_link":
+            return block.value.file.url
 
         return ""
 
@@ -232,6 +235,7 @@ class CallToActionBlock(blocks.StructBlock):
             ("internal_link", blocks.PageChooserBlock()),
             ("external_link", blocks.URLBlock()),
             ("email", blocks.EmailBlock()),
+            ("document_link", DocumentChooserBlock()),
         ],
         required=True,
         max_num=1,

--- a/tbx/core/blocks.py
+++ b/tbx/core/blocks.py
@@ -226,6 +226,11 @@ class ButtonLinkStructValue(blocks.StructValue):
 
         return ""
 
+    def get_button_file_size(self):
+        block = self.get_button_link_block()
+        if block.block_type == "document_link":
+            return block.value.file.size
+
 
 class CallToActionBlock(blocks.StructBlock):
     text = blocks.CharBlock(required=True, max_length=255)

--- a/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/call_to_action.html
+++ b/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/call_to_action.html
@@ -5,7 +5,12 @@
         <p class="call-to-action__text">{{ value.text }}</p>
 
         {% if value.button_text and value.button_link %}
-            <a href="{{ value.get_button_link }}" class="call-to-action__button button">{{ value.button_text }}</a>
+            <a href="{{ value.get_button_link }}" class="call-to-action__button button">
+                {{ value.button_text }}
+                {% if value.get_button_link_block.block_type == "document_link" %}
+                    ({{ value.get_button_file_size|filesizeformat }})
+                {% endif %}
+            </a>
         {% endif %}
     </div>
 </div>

--- a/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/contact_call_to_action.html
+++ b/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/contact_call_to_action.html
@@ -22,7 +22,12 @@
 
     {% for cta in value.call_to_action %}
         {% if cta.value.button_text and cta.value.button_link %}
-            <a href="{{ cta.value.get_button_link }}" class="contact-cta__button button">{{ cta.value.button_text }}</a>
+            <a href="{{ cta.value.get_button_link }}" class="contact-cta__button button">
+                {{ cta.value.button_text }}
+                {% if cta.value.get_button_link_block.block_type == "document_link" %}
+                    ({{ cta.value.get_button_file_size|filesizeformat }})
+                {% endif %}
+            </a>
         {% endif %}
     {% endfor %}
 </div>


### PR DESCRIPTION
[Link to Ticket](https://torchbox.monday.com/boards/1192293412/views/6453316)

### Description of Changes Made
- Add a document download link option for CTAs and Contact CTAs
- In the template, display the file size for document links

### How to Test
Edit any type of page apart from the home page or person page
- Add a 'call to action' block in the body, and test it with a document download
- Add a 'contact call to action' block in the body, and test it with a document download

### Screenshots

<details>
  <summary>Expand to see more</summary>
![Screenshot 2024-06-10 at 11 54 37](https://github.com/torchbox/torchbox.com/assets/771869/10b2395e-091e-4329-bad2-2da9b7bdd000)

![Screenshot 2024-06-10 at 12 20 20](https://github.com/torchbox/torchbox.com/assets/771869/fdc00ad2-e9c1-4d7a-b91a-5180ce694592)

</details>

### MR Checklist

- [x] Add a description of your pull request and instructions for the reviewer to verify your work.
- [x] If your pull request is for a specific ticket, link to it in the description.
- [x] Stay on point and keep it small so the merge request can be easily reviewed.
- [x] Tests and linting passes.

#### Unit tests

- [ ] Added
- [x] Not required

#### Documentation

- [ ] Updated build docs
- [ ] Updated editor guidelines (https://docs.google.com/document/d/1PAWccdQ4tfaZsrEWmpDhvP3GH5RRmBOARFVp4b-kje8/edit?usp=sharing)
- [ ] Updated field spec (https://docs.google.com/spreadsheets/d/1v1yqcSC54Vag4mxmTp8e6ZrnxITqzbjCA4A9XPQdXk8/edit?usp=sharing)
- [x] Not required

#### Browser testing

- [ ] I have tested in the following browsers and environments (edit the list as required)
  - Latest version of Chrome on mac
  - Latest version of Firefox on mac
  - Latest version of Safari on mac
  - Safari on last two versions of iOS
  - Chrome on last two versions of Android
- [x] Not required

#### Data protection

- [x] Not relevant
- [ ] This adds new sources of PII and documents it and modifies Birdbath processors accordingly

#### Accessibility

- [ ] Automated WCAG 2.1 tests pass
- [ ] HTML validation passes
- [ ] Manual WCAG 2.1 tests completed
- [ ] I have tested in a screen reader
- [ ] I have tested in high-contrast mode
- [ ] Any animations removed for prefers-reduced-motion
- [x] Not required

#### Sustainability

- [ ] Images are optimised and lazy-loading used where appropriate
- [ ] SVGs have been optimised
- [ ] Perfomance and transfer of data considered
- [ ] If JavaScript is needed alternatives have been considered
- [x] Not required

#### Pattern library

- [ ] The pattern library component for this template displays correctly, and does not break parent templates
- [ ] The styleguide is updated if relevant
- [x] Changes are not relevant the pattern library
