### PR TITLE
Show a border round the desktop sub menu in high contrast mode

### DIFF
--- a/tbx/static_src/sass/components/navigation/_sub-nav-desktop.scss
+++ b/tbx/static_src/sass/components/navigation/_sub-nav-desktop.scss
@@ -20,6 +20,8 @@ Here we refer to 'level 1 children' as 'level 2' and 'level 2 children' as 'leve
     );
     background-color: var(--color--nav-background);
     padding: $spacer-half $grid-gutters;
+    // for high contrast mode
+    border: 1px solid transparent;
 
     // padding matches grid spacers but we don't want a grid layout for the sub-nav
     @include media-query(large) {
@@ -37,6 +39,7 @@ Here we refer to 'level 1 children' as 'level 2' and 'level 2 children' as 'leve
         // links remain hidden until opened
         visibility: hidden;
         padding: 0;
+        border: 0;
     }
 
     // the unordered list containing the level 2 menu items


### PR DESCRIPTION
No ticket - spotted during light mode testing

### Description of Changes Made

In high contrast mode, the small drop-down menu at desktop had a border, but the larger drop-down menu did not.

### How to Test

View any page at desktop in high contrast mode (test both dark and light colour schemes)
Open the services dropdown - there should now be a border around it, but not around the child menu items.

### Screenshots

<details>
  <summary>Expand to see more</summary>

</details>

### MR Checklist

- [x] Add a description of your pull request and instructions for the reviewer to verify your work.
- [x] If your pull request is for a specific ticket, link to it in the description.
- [x] Stay on point and keep it small so the merge request can be easily reviewed.
- [x] Tests and linting passes.

#### Unit tests

- [ ] Added
- [x] Not required

#### Documentation

- [ ] Updated build docs
- [ ] Updated editor guidelines (See https://intranet.torchbox.com/torchbox-com-project-docs for the private link, for Torchbox employees only)
- [ ] Updated field spec (See https://intranet.torchbox.com/torchbox-com-project-docs for the private link, for Torchbox employees only)
- [x] Not required

#### Browser testing

- [x] I have tested in the following browsers and environments (edit the list as required)
  - Latest version of Chrome on mac
- [ ] Not required

#### Data protection

- [x] Not relevant
- [ ] This adds new sources of PII and documents it and modifies Birdbath processors accordingly

#### Accessibility

- [ ] Automated WCAG 2.1 tests pass
- [ ] HTML validation passes
- [ ] Manual WCAG 2.1 tests completed
- [ ] I have tested in a screen reader
- [x] I have tested in high-contrast mode
- [ ] Any animations removed for prefers-reduced-motion
- [ ] Not required

#### Sustainability

- [ ] Images are optimised and lazy-loading used where appropriate
- [ ] SVGs have been optimised
- [ ] Perfomance and transfer of data considered
- [ ] If JavaScript is needed alternatives have been considered
- [x] Not required

#### Pattern library

- [ ] The pattern library component for this template displays correctly, and does not break parent templates
- [ ] The styleguide is updated if relevant
- [x] Changes are not relevant the pattern library
