### PR TITLE
🚨 Security fix | Wagtail 6.1.3 & Django 4.2.14

### DIFF
--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -41,18 +41,9 @@ As indicated [here](./custom-features/migration-friendly-streamfields.md), this 
 
 - Ensure that the [page themes](custom-features/theme.md) are still working correctly
 
-### Wagtail package dependencies
+### Dark and light mode
 
-We are maintaining our own forks of Wagtail packages at: <https://github.com/torchbox-forks>.
-
-The enables any team member to propose a change to a package, we can all work directly on the work branch and submit it to the original author for consideration.
-
-- [How we work on forked packages (intranet article).](https://intranet.torchbox.com/torchbox-teams/tech-team/working-with-3rd-party-packages/#forking-repositories)
-- [Where we manage forked packages (Monday board).](https://torchbox.monday.com/boards/1124794299)
-
-As much as possible, we want to use the official releases available on PyPI for the Wagtail package dependencies. A temporary solution is to fork the package dependency, tag the working branch, and use the tag in the pyproject file.
-
-### Check these packages for updates
+- Ensure that [light and dark mode](custom-features/modes.md) are still working correctly
 
 #### Lite youtube integration
 
@@ -68,4 +59,22 @@ As much as possible, we want to use the official releases available on PyPI for 
 
 ### Contact snippets in footer
 
-- Ensure that these still display all the relevant content - title, text, photo, role contact link and button text
+- Ensure that these still display all the relevant content - title, text, photo, role contact link, button text and email text
+
+## Wagtail package dependencies
+
+We are maintaining our own forks of Wagtail packages at: <https://github.com/torchbox-forks>.
+
+The enables any team member to propose a change to a package, we can all work directly on the work branch and submit it to the original author for consideration.
+
+- [How we work on forked packages (intranet article).](https://intranet.torchbox.com/torchbox-teams/tech-team/working-with-3rd-party-packages/#forking-repositories)
+- [Where we manage forked packages (Monday board).](https://torchbox.monday.com/boards/1124794299)
+
+As much as possible, we want to use the official releases available on PyPI for the Wagtail package dependencies. A temporary solution is to fork the package dependency, tag the working branch, and use the tag in the pyproject file.
+
+### Check these packages for updates
+
+(This list may not be exhaustive)
+
+- [lite youtube](front-end/lite-youtube.md)
+- [wagtail markdown](front-end/markdown-codehilite.md)

--- a/poetry.lock
+++ b/poetry.lock
@@ -570,13 +570,13 @@ typing_extensions = ">=3.10.0.0"
 
 [[package]]
 name = "django"
-version = "4.2.13"
+version = "4.2.14"
 description = "A high-level Python web framework that encourages rapid development and clean, pragmatic design."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "Django-4.2.13-py3-none-any.whl", hash = "sha256:a17fcba2aad3fc7d46fdb23215095dbbd64e6174bf4589171e732b18b07e426a"},
-    {file = "Django-4.2.13.tar.gz", hash = "sha256:837e3cf1f6c31347a1396a3f6b65688f2b4bb4a11c580dcb628b5afe527b68a5"},
+    {file = "Django-4.2.14-py3-none-any.whl", hash = "sha256:3ec32bc2c616ab02834b9cac93143a7dc1cdcd5b822d78ac95fc20a38c534240"},
+    {file = "Django-4.2.14.tar.gz", hash = "sha256:fc6919875a6226c7ffcae1a7d51e0f2ceaf6f160393180818f6c95f51b1e7b96"},
 ]
 
 [package.dependencies]

--- a/poetry.lock
+++ b/poetry.lock
@@ -2422,13 +2422,13 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 
 [[package]]
 name = "wagtail"
-version = "6.1.2"
+version = "6.1.3"
 description = "A Django content management system."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "wagtail-6.1.2-py3-none-any.whl", hash = "sha256:6858f89c4a050cbbb1702ce3cb605b8360b736c296c93193c4e72ea87427d431"},
-    {file = "wagtail-6.1.2.tar.gz", hash = "sha256:fdb82c6cd6f6ae5c1f7b2312166969d8601015b65cbb29ad120efac727d399c1"},
+    {file = "wagtail-6.1.3-py3-none-any.whl", hash = "sha256:b6c4d5705adf51a5e49ea416032dd0a6534588fc31c5c9a95f698e6ddec0a203"},
+    {file = "wagtail-6.1.3.tar.gz", hash = "sha256:8f4908ab1b6b963a8aa7adf8f0ec738cd1dc79b9816c6d5f59018f600a404378"},
 ]
 
 [package.dependencies]


### PR DESCRIPTION
This PR 

- updates wagtail from 6.1.2 to 6.1.3, which was released on Thursday July 11th 2024 to address a denial-of-service vulnerability in Wagtail.
- updates django from 4.2.13 to 4.2.14, which was released on Tuesday July 9th, 2024 to address two security issues with severity “moderate” and two security issues with severity “low” in 4.2.13.

[Monday board](https://torchbox.monday.com/boards/1560489892)

<details><summary>More details on the Wagtail update</summary>

- https://docs.wagtail.org/en/latest/releases/6.1.3.html
- https://github.com/wagtail/wagtail/security/advisories/GHSA-jmp3-39vp-fwg8

</details>

<details><summary>More details on the Django update</summary>

- https://docs.djangoproject.com/en/5.0/releases/4.2.14/
- https://www.djangoproject.com/weblog/2024/jul/09/security-releases/

</details>