### PR TITLE
Add promo block to the standard page block options

### DIFF
--- a/tbx/core/blocks.py
+++ b/tbx/core/blocks.py
@@ -894,6 +894,10 @@ class StoryBlock(blocks.StreamBlock):
         template = "patterns/molecules/streamfield/stream_block.html"
 
 
+class StandardPageStoryBlock(StoryBlock):
+    promo = PromoBlock()
+
+
 class HomePageStoryBlock(blocks.StreamBlock):
     showcase = ShowcaseBlock(label="Standard showcase")
     homepage_showcase = HomepageShowcaseBlock(label="Large showcase with icons")

--- a/tbx/core/models.py
+++ b/tbx/core/models.py
@@ -18,7 +18,7 @@ from wagtail.models import Orderable, Page
 from wagtail.search import index
 from wagtail.snippets.models import register_snippet
 
-from .blocks import HomePageStoryBlock, StoryBlock
+from .blocks import HomePageStoryBlock, StandardPageStoryBlock, StoryBlock
 
 
 @register_snippet
@@ -173,7 +173,7 @@ class StandardPage(
 ):
     template = "patterns/pages/standard/standard_page.html"
 
-    body = StreamField(StoryBlock())
+    body = StreamField(StandardPageStoryBlock())
 
     content_panels = Page.content_panels + [
         FieldPanel("body"),

--- a/tbx/core/models.py
+++ b/tbx/core/models.py
@@ -18,7 +18,7 @@ from wagtail.models import Orderable, Page
 from wagtail.search import index
 from wagtail.snippets.models import register_snippet
 
-from .blocks import HomePageStoryBlock, StandardPageStoryBlock, StoryBlock
+from .blocks import HomePageStoryBlock, StandardPageStoryBlock
 
 
 @register_snippet


### PR DESCRIPTION
[Link to Ticket](https://torchbox.monday.com/boards/1192293412/pulses/1535324182)

### Description of Changes Made

- Adds the promo block to the standard page, but not to other page types like work or blog
- The service page already had the promo block available so no change was necessary

### How to Test

On your local build, edit any standard page, and test adding a promo block to the body. Ensure you can't add a promo blog to work page types or to blogs.

### Screenshots

<details>
  <summary>Expand to see more</summary>
<img width="1051" alt="Screenshot 2024-07-17 at 08 27 21" src="https://github.com/user-attachments/assets/d8102cb6-6f66-48aa-a0d1-8504a7bb1f14">

</details>

### MR Checklist

- [x] Add a description of your pull request and instructions for the reviewer to verify your work.
- [x] If your pull request is for a specific ticket, link to it in the description.
- [x] Stay on point and keep it small so the merge request can be easily reviewed.
- [x] Tests and linting passes.

#### Unit tests

- [ ] Added
- [ ] Not required

#### Documentation

- [ ] Updated build docs
- [ ] Updated editor guidelines (See https://intranet.torchbox.com/torchbox-com-project-docs for the private link, for Torchbox employees only)
- [x] Updated field spec (See https://intranet.torchbox.com/torchbox-com-project-docs for the private link, for Torchbox employees only)
- [ ] Not required

#### Browser testing

- [x] I have tested in the following browsers and environments (edit the list as required)
  - Latest version of Chrome on mac
- [ ] Not required

#### Data protection

- [x] Not relevant
- [ ] This adds new sources of PII and documents it and modifies Birdbath processors accordingly

#### Accessibility

- [ ] Automated WCAG 2.1 tests pass
- [ ] HTML validation passes
- [ ] Manual WCAG 2.1 tests completed
- [ ] I have tested in a screen reader
- [ ] I have tested in high-contrast mode
- [ ] Any animations removed for prefers-reduced-motion
- [x] Not required

#### Sustainability

- [ ] Images are optimised and lazy-loading used where appropriate
- [ ] SVGs have been optimised
- [ ] Perfomance and transfer of data considered
- [ ] If JavaScript is needed alternatives have been considered
- [x] Not required

#### Pattern library

- [ ] The pattern library component for this template displays correctly, and does not break parent templates
- [ ] The styleguide is updated if relevant
- [x] Changes are not relevant the pattern library
