### PR TITLE
Tabbed paragraph changes

### DIFF
--- a/tbx/core/blocks.py
+++ b/tbx/core/blocks.py
@@ -620,16 +620,19 @@ class TabbedParagraphSectionsListBlock(blocks.ListBlock):
             item_errors = ErrorList()
 
             if button_values.get("button_link") and button_values.get("button_url"):
-                item_errors.append(ValidationError("You must specify either a page link or a URL, not both."))
-
-            if (
-                button_values.get("button_text")
-                and (
-                    not button_values.get("button_link")
-                    and not button_values.get("button_url")
+                item_errors.append(
+                    ValidationError(
+                        "You must specify either a page link or a URL, not both."
+                    )
                 )
+
+            if button_values.get("button_text") and (
+                not button_values.get("button_link")
+                and not button_values.get("button_url")
             ):
-                item_errors.append("You must specify a button link or URL for the button text you have provided.")
+                item_errors.append(
+                    "You must specify a button link or URL for the button text you have provided."
+                )
 
             if item_errors:
                 errors[i] = item_errors
@@ -669,9 +672,7 @@ class TabbedParagraphBlock(blocks.StructBlock):
             errors["title"].append(ValidationError(message))
 
         if errors:
-            raise blocks.StructBlockValidationError(
-                block_errors=errors
-            )
+            raise blocks.StructBlockValidationError(block_errors=errors)
 
         return value
 

--- a/tbx/core/blocks.py
+++ b/tbx/core/blocks.py
@@ -605,10 +605,45 @@ class PromoBlock(blocks.StructBlock):
         group = "Calls to action"
 
 
+class TabbedParagraphSectionsListBlock(blocks.ListBlock):
+    def clean(self, value):
+        result = super().clean(value)
+        errors = {}
+
+        for i in range(0, len(result)):
+            button_values = {
+                "button_link": result[i]["button_link"],
+                "button_text": result[i]["button_text"],
+                "button_url": result[i]["button_url"],
+            }
+
+            item_errors = ErrorList()
+
+            if button_values.get("button_link") and button_values.get("button_url"):
+                item_errors.append(ValidationError("You must specify either a page link or a URL, not both."))
+
+            if (
+                button_values.get("button_text")
+                and (
+                    not button_values.get("button_link")
+                    and not button_values.get("button_url")
+                )
+            ):
+                item_errors.append("You must specify a button link or URL for the button text you have provided.")
+
+            if item_errors:
+                errors[i] = item_errors
+
+        if errors:
+            raise blocks.ListBlockValidationError(block_errors=errors)
+
+        return result
+
+
 class TabbedParagraphBlock(blocks.StructBlock):
     title = blocks.CharBlock(max_length=255, required=False)
-    intro = blocks.TextBlock(label="Introduction", required=False)
-    tabbed_paragraph_sections = blocks.ListBlock(
+    intro = blocks.RichTextBlock(label="Introduction", required=False)
+    tabbed_paragraph_sections = TabbedParagraphSectionsListBlock(
         blocks.StructBlock(
             [
                 ("name", blocks.CharBlock()),
@@ -616,6 +651,7 @@ class TabbedParagraphBlock(blocks.StructBlock):
                 ("text", blocks.RichTextBlock()),
                 ("button_text", blocks.CharBlock(required=False)),
                 ("button_link", blocks.PageChooserBlock(required=False)),
+                ("button_url", blocks.URLBlock(required=False)),
             ],
             help_text="Add a tabbed paragraph, with a name, summary, text and an optional page link & button text",
             icon="breadcrumb-expand",
@@ -627,29 +663,14 @@ class TabbedParagraphBlock(blocks.StructBlock):
     def clean(self, value):
         value = super().clean(value)
         errors = defaultdict(ErrorList)
-        non_block_errors = ErrorList()
 
         if value["intro"] and not value["title"]:
             message = "You cannot add an intro without also adding a title"
             errors["title"].append(ValidationError(message))
 
-        for tabbed_paragraph_section in value["tabbed_paragraph_sections"]:
-            button_values = {
-                "button_link": tabbed_paragraph_section["button_link"],
-                "button_text": tabbed_paragraph_section["button_text"],
-            }
-
-            if any(button_values.values()) and not all(button_values.values()):
-                message = "There must be a value for both button link and text, if one has a value."
-
-                for key, value in button_values.items():
-                    if not value:
-                        errors[key].append(message)
-                        non_block_errors.append(ValidationError(message))
-
-        if errors or non_block_errors:
+        if errors:
             raise blocks.StructBlockValidationError(
-                block_errors=errors, non_block_errors=non_block_errors
+                block_errors=errors
             )
 
         return value

--- a/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/tabbed_paragraph_block.html
+++ b/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/tabbed_paragraph_block.html
@@ -40,7 +40,7 @@
                 <div class="tabs__panel-summary">
                     {{ item.summary }}
                 </div>
-                <div class="tabs__panel-text">
+                <div class="tabs__panel-text rich-text">
                     {{ item.text|richtext }}
                 </div>
                 {% if item.button_text%}
@@ -75,7 +75,7 @@
                 <div class="tabs-mobile__summary-text">
                     {{ tab.summary }}
                 </div>
-                <div class="tabs-mobile__text">
+                <div class="tabs-mobile__text rich-text">
                     {{ tab.text|richtext }}
                 </div>
                 {% if tab.button_text %}

--- a/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/tabbed_paragraph_block.html
+++ b/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/tabbed_paragraph_block.html
@@ -9,7 +9,7 @@
     {% endif %}
 
     {% if value.intro %}
-        <p class="tabbed-paragraph__intro">{{ value.intro }}</p>
+        <div class="tabbed-paragraph__intro rich-text">{{ value.intro }}</div>
     {% endif %}
 
     {# desktop - tabs #}
@@ -43,8 +43,16 @@
                 <div class="tabs__panel-text">
                     {{ item.text|richtext }}
                 </div>
-                {% if item.button_text and item.button_link %}
-                    <a href="{% pageurl item.button_link %}" class="button tabs__panel-button">{{ item.button_text }}</a>
+                {% if item.button_text%}
+                    {% if item.button_link or item.button_url %}
+                        {% if item.button_link %}
+                            <a href="{% pageurl item.button_link %}" class="button tabs__panel-button">
+                        {% else %}
+                            <a href="{{ item.button_url }}" class="button tabs__panel-button">
+                        {% endif %}
+                            {{ item.button_text }}
+                        </a>
+                    {% endif %}
                 {% endif %}
             </div>
         {% endfor %}

--- a/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/tabbed_paragraph_block.html
+++ b/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/tabbed_paragraph_block.html
@@ -78,8 +78,16 @@
                 <div class="tabs-mobile__text">
                     {{ tab.text|richtext }}
                 </div>
-                {% if tab.button_text and tab.button_link %}
-                    <a href="{% pageurl tab.button_link %}" class="button tabs-mobile__button">{{ tab.button_text }}</a>
+                {% if tab.button_text %}
+                    {% if tab.button_link or tab.button_url %}
+                        {% if tab.button_link %}
+                            <a href="{% pageurl tab.button_link %}" class="button tabs-mobile__button">
+                        {% else %}
+                            <a href="{{ tab.button_url }}" class="button tabs-mobile__button">
+                        {% endif %}
+                        {{ tab.button_text }}
+                        </a>
+                    {% endif %}
                 {% endif %}
             </div>
         </details>

--- a/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/tabbed_paragraph_block.html
+++ b/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/tabbed_paragraph_block.html
@@ -50,7 +50,7 @@
                         {% else %}
                             <a href="{{ item.button_url }}" class="button tabs__panel-button">
                         {% endif %}
-                            {{ item.button_text }}
+                        {{ item.button_text }}
                         </a>
                     {% endif %}
                 {% endif %}

--- a/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/tabbed_paragraph_block.yaml
+++ b/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/tabbed_paragraph_block.yaml
@@ -1,7 +1,7 @@
 context:
   value:
     title: Putting people at the heart of our process
-    intro: Cover the full spectrum of SEO, so whether you need a quick site health check, some training and support or a full SEO strategy, we can help.
+    intro: <p>Cover the full <a href="#">spectrum of SEO</a>, so whether you need a quick site health check, some training and support or a full SEO strategy, we can help.</p>
     tabbed_paragraph_sections:
       - name: Strategy and consultancy
         summary: Gathering insights into people’s needs and behaviours to inform and guide design solutions.


### PR DESCRIPTION
[Link to Ticket](https://torchbox.monday.com/boards/1192293412/pulses/1535324209)

### Description of Changes Made

- Make the intro rich text
- Allow external links in the buttons
- Update validation

### How to Test

Edit a service page in a local build, and add a tabbed paragraph block, and fill out all the fields.

- For each tab, you should be able to add a button url (external) or a button link (internal), but not both
- For each tab, you should not be able to add button text without also adding either a button link or a button url

### Screenshots

<details>
  <summary>Expand to see more</summary>

Shows a link in the introduction field

<img width="1439" alt="Screenshot 2024-07-17 at 09 52 26" src="https://github.com/user-attachments/assets/83a621ea-24ad-451d-9a17-4f199ed4df62">

Shows the new button url field:

<img width="727" alt="Screenshot 2024-07-17 at 14 46 16" src="https://github.com/user-attachments/assets/3ba4d529-ed97-48ae-8f43-776263905cb2">

</details>

### MR Checklist

- [x] Add a description of your pull request and instructions for the reviewer to verify your work.
- [x] If your pull request is for a specific ticket, link to it in the description.
- [x] Stay on point and keep it small so the merge request can be easily reviewed.
- [x] Tests and linting passes.

#### Unit tests

- [ ] Added
- [x] Not required

#### Documentation

- [ ] Updated build docs
- [ ] Updated editor guidelines (See https://intranet.torchbox.com/torchbox-com-project-docs for the private link, for Torchbox employees only)
- [ ] Updated field spec (See https://intranet.torchbox.com/torchbox-com-project-docs for the private link, for Torchbox employees only)
- [x] Not required

#### Browser testing

- [x] I have tested in the following browsers and environments (edit the list as required)
  - Latest version of Chrome on mac
- [ ] Not required

#### Data protection

- [x] Not relevant
- [ ] This adds new sources of PII and documents it and modifies Birdbath processors accordingly

#### Accessibility

- [ ] Automated WCAG 2.1 tests pass
- [ ] HTML validation passes
- [ ] Manual WCAG 2.1 tests completed
- [ ] I have tested in a screen reader
- [ ] I have tested in high-contrast mode
- [ ] Any animations removed for prefers-reduced-motion
- [x] Not required

#### Sustainability

- [ ] Images are optimised and lazy-loading used where appropriate
- [ ] SVGs have been optimised
- [ ] Perfomance and transfer of data considered
- [ ] If JavaScript is needed alternatives have been considered
- [x] Not required

#### Pattern library

- [x] The pattern library component for this template displays correctly, and does not break parent templates
- [ ] The styleguide is updated if relevant
- [ ] Changes are not relevant the pattern library
