### PR TITLE
a11y menu issue when focus moves away

### DIFF
--- a/tbx/project_styleguide/templates/patterns/navigation/components/includes/subnav-child-menu.html
+++ b/tbx/project_styleguide/templates/patterns/navigation/components/includes/subnav-child-menu.html
@@ -4,7 +4,7 @@
     <ul class="sub-nav-desktop__list sub-nav-desktop__list--child">
         {% for page in pages %}
             <li class="sub-nav-desktop__item">
-                <a class="sub-nav-desktop__link sub-nav-desktop__link--child sub-nav-desktop__link--no-children" href="{% pageurl page %}">
+                <a class="sub-nav-desktop__link sub-nav-desktop__link--child sub-nav-desktop__link--no-children" href="{% pageurl page %}" {% if last_menu_item and forloop.last %}data-last-menu-item-desktop{% endif %}>
                     {{ page.nav_text }}
                 </a>
             </li>

--- a/tbx/project_styleguide/templates/patterns/navigation/components/includes/subnav-menu-mini.html
+++ b/tbx/project_styleguide/templates/patterns/navigation/components/includes/subnav-menu-mini.html
@@ -8,6 +8,9 @@
                 <a
                     class="sub-nav-desktop-mini__link"
                     href="{% pageurl link %}"
+                    {% if forloop.last %}
+                        data-last-menu-item-desktop
+                    {% endif %}
                 >
                     {{ link.nav_text }}
                 </a>

--- a/tbx/project_styleguide/templates/patterns/navigation/components/includes/subnav-menu.html
+++ b/tbx/project_styleguide/templates/patterns/navigation/components/includes/subnav-menu.html
@@ -8,10 +8,14 @@
                     <a
                         class="sub-nav-desktop__link {% if children and child_display != 'hide_children' %}sub-nav-desktop__link--has-children{% else %}sub-nav-desktop__link--no-children{% endif %}"
                         href="{% pageurl link %}"
+                        {% if forloop.last %}
+                            {% if not children or child_display == 'hide_children' %}data-last-menu-item-desktop{% endif %}{% endif %}
                     >
                         {{ link.nav_text }}
                     </a>
-                    {% include "patterns/navigation/components/includes/subnav-child-menu.html" with pages=children %}
+                    {% if children and child_display != 'hide_children' %}
+                        {% include "patterns/navigation/components/includes/subnav-child-menu.html" with pages=children last_menu_item=forloop.last %}
+                    {% endif %}
                 {% endwith %}
             </li>
         {% endfor %}

--- a/tbx/project_styleguide/templates/patterns/navigation/components/primary-nav-mobile.html
+++ b/tbx/project_styleguide/templates/patterns/navigation/components/primary-nav-mobile.html
@@ -17,6 +17,7 @@ The `child_display` has 3 possible values:
                         data-open-subnav aria-haspopup="true" aria-expanded="false"
                     {% endif %}
                     href="{% if link.page %}{% pageurl link.page %}{% elif link.external_link %}{{ link.external_link }}{% endif %}"
+                    {% if forloop.last %}data-last-menu-item-mobile{% endif %}
                 >
                     <span class="primary-nav-mobile__text">{{ link.text }}</span>
                     {% if children and child_display != 'hide_children' %}

--- a/tbx/static_src/javascript/components/desktop-sub-menu.js
+++ b/tbx/static_src/javascript/components/desktop-sub-menu.js
@@ -15,6 +15,9 @@ class DesktopSubMenu {
             '[data-desktop-menu] [data-has-subnav]',
         );
         this.activeClass = 'active';
+        this.lastMenuItems = document.querySelectorAll(
+            '[data-last-menu-item-desktop]',
+        );
         this.bindEventListeners();
     }
 
@@ -52,13 +55,13 @@ class DesktopSubMenu {
             }
         });
 
-        document.addEventListener('focusin', (e) => {
-            const inSubMenu = !!e.target.closest('[data-desktop-menu]');
-            if (!inSubMenu) {
+        // Close the desktop menu when the focus moves away from the last item
+        this.lastMenuItems.forEach((item) => {
+            item.addEventListener('focusout', () => {
                 this.toggleNode.classList.remove('active');
                 this.node.setAttribute('aria-expanded', 'false');
                 this.body.classList.remove('no-scroll');
-            }
+            });
         });
     }
 }

--- a/tbx/static_src/javascript/components/desktop-sub-menu.js
+++ b/tbx/static_src/javascript/components/desktop-sub-menu.js
@@ -51,6 +51,15 @@ class DesktopSubMenu {
                 this.body.classList.add('no-scroll');
             }
         });
+
+        document.addEventListener('focusin', (e) => {
+            const inSubMenu = !!e.target.closest('[data-desktop-menu]');
+            if (!inSubMenu) {
+                this.toggleNode.classList.remove('active');
+                this.node.setAttribute('aria-expanded', 'false');
+                this.body.classList.remove('no-scroll');
+            }
+        });
     }
 }
 

--- a/tbx/static_src/javascript/components/mobile-menu.js
+++ b/tbx/static_src/javascript/components/mobile-menu.js
@@ -7,6 +7,9 @@ class MobileMenu {
         this.node = node;
         this.body = document.querySelector('body');
         this.mobileMenu = document.querySelector('[data-mobile-menu]');
+        this.lastMenuItem = document.querySelector(
+            '[data-last-menu-item-mobile]',
+        );
 
         this.state = {
             open: false,
@@ -27,6 +30,14 @@ class MobileMenu {
                     this.close();
                     this.state.open = false;
                 }
+            }
+        });
+
+        // Close the mobile menu when the focus moves away from the last item in the top level
+        this.lastMenuItem.addEventListener('focusout', () => {
+            if (this.state.open) {
+                this.close();
+                this.state.open = false;
             }
         });
     }


### PR DESCRIPTION
[Link to Ticket](https://torchbox.monday.com/boards/1192293412/pulses/1500563118)

### Description of Changes Made

There was an issue with both the mobile drop down menu and the desktop drop down menus when navigating with the keyboard. When focus moved away, the menu remained open and obscured the content behind it. This adds fixes as follows:

- For the mobile dropdown menu, we already have checks for when the last item is left in the subnav menus - it returns to the parent item - this has not changed
- At the top level of the mobile menu, if you tab past the last item, it now closes the menu.
- For the desktop menus, if you tab past the last item, it now closes the menu. In the large drop-down menu that shows children and grandchildren, it is slightly more complicated to determine the last item - as the last child may or may not have further children.

### How to Test

On any page in a local build, view the destkop menu. Navigate through the items with your keyboard - as you focus away from the last item, the menu should close.

On any page in a local build, view the mobile menu. Navigate through the top level items with your keyboard - as you focus away from the last item, the menu should close. Check the subnavigation items for children and grandchildren - as you focus away from the last menu item, the focus should return to the next item in the parent menu.

### Screenshots

<details>
  <summary>Expand to see more</summary>

</details>

### MR Checklist

- [ ] Add a description of your pull request and instructions for the reviewer to verify your work.
- [ ] If your pull request is for a specific ticket, link to it in the description.
- [ ] Stay on point and keep it small so the merge request can be easily reviewed.
- [ ] Tests and linting passes.

#### Unit tests

- [ ] Added
- [ ] Not required

#### Documentation

- [ ] Updated build docs
- [ ] Updated editor guidelines (See https://intranet.torchbox.com/torchbox-com-project-docs for the private link, for Torchbox employees only)
- [ ] Updated field spec (See https://intranet.torchbox.com/torchbox-com-project-docs for the private link, for Torchbox employees only)
- [ ] Not required

#### Browser testing

- [ ] I have tested in the following browsers and environments (edit the list as required)
  - Latest version of Chrome on mac
  - Latest version of Firefox on mac
  - Latest version of Safari on mac
  - Safari on last two versions of iOS
  - Chrome on last two versions of Android
- [ ] Not required

#### Data protection

- [ ] Not relevant
- [ ] This adds new sources of PII and documents it and modifies Birdbath processors accordingly

#### Accessibility

- [ ] Automated WCAG 2.1 tests pass
- [ ] HTML validation passes
- [ ] Manual WCAG 2.1 tests completed
- [ ] I have tested in a screen reader
- [ ] I have tested in high-contrast mode
- [ ] Any animations removed for prefers-reduced-motion
- [ ] Not required

#### Sustainability

- [ ] Images are optimised and lazy-loading used where appropriate
- [ ] SVGs have been optimised
- [ ] Perfomance and transfer of data considered
- [ ] If JavaScript is needed alternatives have been considered
- [ ] Not required

#### Pattern library

- [ ] The pattern library component for this template displays correctly, and does not break parent templates
- [ ] The styleguide is updated if relevant
- [ ] Changes are not relevant the pattern library
