### PR TITLE
Add blog chooser and work chooser blocks to the standard page

### DIFF
--- a/tbx/core/blocks.py
+++ b/tbx/core/blocks.py
@@ -440,10 +440,22 @@ class BlogChooserBlock(blocks.StructBlock):
         max_num=3,
     )
 
+    def get_context(self, value, parent_context=None):
+        context = super().get_context(value, parent_context=parent_context)
+        context['is_standard_page'] = False
+        return context
+
     class Meta:
         icon = "link"
         template = "patterns/molecules/streamfield/blocks/blog_chooser_block.html"
         group = "Custom"
+
+
+class BlogChooserStandardPageBlock(BlogChooserBlock):
+    def get_context(self, value, parent_context=None):
+        context = super().get_context(value, parent_context=parent_context)
+        context['is_standard_page'] = True
+        return context
 
 
 class WorkChooserBlock(blocks.StructBlock):
@@ -481,12 +493,20 @@ class WorkChooserBlock(blocks.StructBlock):
         context["work_pages"] = [
             work_pages[_id] for _id in work_page_ids if _id in work_pages
         ]
+        context['is_standard_page'] = False
         return context
 
     class Meta:
         icon = "link"
         template = "patterns/molecules/streamfield/blocks/work_chooser_block.html"
         group = "Custom"
+
+
+class WorkChooserStandardPageBlock(WorkChooserBlock):
+    def get_context(self, value, parent_context=None):
+        context = super().get_context(value, parent_context=parent_context)
+        context['is_standard_page'] = True
+        return context
 
 
 class EventLinkStructValue(ButtonLinkStructValue):
@@ -896,6 +916,8 @@ class StoryBlock(blocks.StreamBlock):
 
 class StandardPageStoryBlock(StoryBlock):
     promo = PromoBlock()
+    blog_chooser = BlogChooserStandardPageBlock()
+    work_chooser = WorkChooserStandardPageBlock()
 
 
 class HomePageStoryBlock(blocks.StreamBlock):

--- a/tbx/core/blocks.py
+++ b/tbx/core/blocks.py
@@ -442,7 +442,7 @@ class BlogChooserBlock(blocks.StructBlock):
 
     def get_context(self, value, parent_context=None):
         context = super().get_context(value, parent_context=parent_context)
-        context['is_standard_page'] = False
+        context["is_standard_page"] = False
         return context
 
     class Meta:
@@ -454,7 +454,7 @@ class BlogChooserBlock(blocks.StructBlock):
 class BlogChooserStandardPageBlock(BlogChooserBlock):
     def get_context(self, value, parent_context=None):
         context = super().get_context(value, parent_context=parent_context)
-        context['is_standard_page'] = True
+        context["is_standard_page"] = True
         return context
 
 
@@ -493,7 +493,7 @@ class WorkChooserBlock(blocks.StructBlock):
         context["work_pages"] = [
             work_pages[_id] for _id in work_page_ids if _id in work_pages
         ]
-        context['is_standard_page'] = False
+        context["is_standard_page"] = False
         return context
 
     class Meta:
@@ -505,7 +505,7 @@ class WorkChooserBlock(blocks.StructBlock):
 class WorkChooserStandardPageBlock(WorkChooserBlock):
     def get_context(self, value, parent_context=None):
         context = super().get_context(value, parent_context=parent_context)
-        context['is_standard_page'] = True
+        context["is_standard_page"] = True
         return context
 
 

--- a/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/blog_chooser_block.html
+++ b/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/blog_chooser_block.html
@@ -1,6 +1,10 @@
 {% load wagtailcore_tags %}
 
-{% include "patterns/atoms/motif-heading/motif-heading.html" with heading_level=2 heading=value.featured_blog_heading classes="motif-heading--two motif-heading--static  motif-heading--half-width   section-title--related-posts" %}
+{% if is_standard_page %}
+    <h2 class="heading heading--two-b grid__heading mb-spacerMedium">{{ value.featured_blog_heading }}</h2>
+{% else %}
+    {% include "patterns/atoms/motif-heading/motif-heading.html" with heading_level=2 heading=value.featured_blog_heading classes="motif-heading--two motif-heading--static  motif-heading--half-width   section-title--related-posts" %}
+{% endif %}
 
 <ul class="grid__related-posts streamfield__related-posts mb-spacerMedium lg:mb-spacerLarge">
     {% for blog_page in value.blog_pages %}

--- a/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/work_chooser_block.html
+++ b/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/work_chooser_block.html
@@ -1,7 +1,11 @@
 {% load wagtailcore_tags %}
 
 {% if work_pages %}
-    {% include "patterns/atoms/motif-heading/motif-heading.html" with heading_level=2 heading=value.featured_work_heading classes="motif-heading--two motif-heading--static  motif-heading--half-width section-title--related-posts" %}
+    {% if is_standard_page %}
+        <h2 class="heading heading--two-b grid__heading mb-spacerMedium">{{ value.featured_work_heading }}</h2>
+    {% else %}
+        {% include "patterns/atoms/motif-heading/motif-heading.html" with heading_level=2 heading=value.featured_work_heading classes="motif-heading--two motif-heading--static  motif-heading--half-width section-title--related-posts" %}
+    {% endif %}
 
     <ul class="grid__related-posts streamfield__related-posts mb-spacerMedium lg:mb-spacerLarge">
         {% for work_page in work_pages %}

--- a/tbx/static_src/sass/components/_grid.scss
+++ b/tbx/static_src/sass/components/_grid.scss
@@ -319,6 +319,17 @@
         grid-column: 5 / span 1;
     }
 
+    // standard page adjustments for blog chooser and work chooser
+    .template-standard-page & {
+        &__related-posts {
+            grid-column: 2 / span 4;
+
+            @include media-query(large) {
+                grid-column: 4 / span 7;
+            }
+        }
+    }
+
     // Move everything over by 1 column on the blog page and work pages
     .template-blog-page &,
     .template-work-page & {


### PR DESCRIPTION
[Link to Ticket](https://torchbox.monday.com/boards/1192293412/pulses/1466792983)

### Description of Changes Made

- Make the blog chooser and work chooser blocks available on the standard page
- Modify the context for the template so we can make some styling changes for when they appear on the standard page

### How to Test

- Edit a standard page, and select a 'blog chooser' and a 'work chooser' block and add some test content
- Check that the title and posts below are aligned, and the title is not using the pretty up-cap styling
- Edit a service page and select a 'blog chooser' and a 'work chooser' block and add some test content
- Check that the posts are inset below the title, and that the title does use the pretty up-cap styling

### Screenshots

<details>
  <summary>Expand to see more</summary>

Blog chooser and work chooser on a standard page:

![screencapture-localhost-8000-standard-page-test-2024-07-23-12_08_51](https://github.com/user-attachments/assets/a0570913-e079-41fa-9985-f2c7d2ede862)

Blog chooser and work chooser on a service page:

![screencapture-localhost-8000-services-digital-products-and-services-research-design-2024-07-23-12_11_08](https://github.com/user-attachments/assets/ddd43131-aa87-416a-89bc-e69565cf086b)

</details>

### MR Checklist

- [x] Add a description of your pull request and instructions for the reviewer to verify your work.
- [x] If your pull request is for a specific ticket, link to it in the description.
- [x] Stay on point and keep it small so the merge request can be easily reviewed.
- [x] Tests and linting passes.

#### Unit tests

- [ ] Added
- [x] Not required

#### Documentation

- [ ] Updated build docs
- [ ] Updated editor guidelines (See https://intranet.torchbox.com/torchbox-com-project-docs for the private link, for Torchbox employees only)
- [ ] Updated field spec (See https://intranet.torchbox.com/torchbox-com-project-docs for the private link, for Torchbox employees only)
- [x] Not required

#### Browser testing

- [x] I have tested in the following browsers and environments (edit the list as required)
  - Latest version of Chrome on mac
- [ ] Not required

#### Data protection

- [x] Not relevant
- [ ] This adds new sources of PII and documents it and modifies Birdbath processors accordingly

#### Accessibility

- [ ] Automated WCAG 2.1 tests pass
- [ ] HTML validation passes
- [ ] Manual WCAG 2.1 tests completed
- [ ] I have tested in a screen reader
- [ ] I have tested in high-contrast mode
- [ ] Any animations removed for prefers-reduced-motion
- [x] Not required

#### Sustainability

- [ ] Images are optimised and lazy-loading used where appropriate
- [ ] SVGs have been optimised
- [ ] Perfomance and transfer of data considered
- [ ] If JavaScript is needed alternatives have been considered
- [x] Not required

#### Pattern library

- [ ] The pattern library component for this template displays correctly, and does not break parent templates
- [ ] The styleguide is updated if relevant
- [x] Changes are not relevant the pattern library
