### PR TITLE
Error page optimisations

### DIFF
--- a/cloudflare/workers.js
+++ b/cloudflare/workers.js
@@ -74,9 +74,10 @@ const REPLACE_STRIPPED_QUERYSTRING_ON_REDIRECT_LOCATION = false;
 // Disabled by default, but highly recommended
 const STRIP_VALUELESS_QUERYSTRING_KEYS = false;
 
-// Only these status codes should be considered cacheable
+// Only these status codes should be considered cacheable.
 // (from https://www.w3.org/Protocols/rfc2616/rfc2616-sec13.html#sec13.4)
-const CACHABLE_HTTP_STATUS_CODES = [200, 203, 206, 300, 301, 410];
+// 404 is added to reduce server load on spammed requests.
+const CACHABLE_HTTP_STATUS_CODES = [200, 203, 206, 300, 301, 410, 404];
 
 addEventListener('fetch', (event) => {
     event.respondWith(main(event));

--- a/tbx/core/tests/test_views.py
+++ b/tbx/core/tests/test_views.py
@@ -110,11 +110,6 @@ class TestModeSwitcherView(TestCase):
 class PageNotFoundTestCase(TestCase):
     url = "/does-not-exist/"
 
-    def test_accessible(self) -> None:
-        response = self.client.get(self.url)
-        self.assertEqual(response.status_code, 404)
-        self.assertIn("text/html", response.headers["content-type"])
-
     def test_accept_html(self) -> None:
         response = self.client.get(self.url, headers={"Accept": "text/html"})
         self.assertEqual(response.status_code, 404)
@@ -131,3 +126,26 @@ class PageNotFoundTestCase(TestCase):
         )
         self.assertEqual(response.status_code, 404)
         self.assertIn("text/plain", response.headers["content-type"])
+
+    def test_missing_accept_header(self) -> None:
+        response = self.client.get(self.url, headers={"Accept": ""})
+        self.assertEqual(response.status_code, 404)
+        self.assertIn("text/plain", response.headers["content-type"])
+
+    def test_wildcard_accept_header(self) -> None:
+        response = self.client.get(self.url, headers={"Accept": "*/*"})
+        self.assertEqual(response.status_code, 404)
+        self.assertIn("text/plain", response.headers["content-type"])
+
+    def test_browser_request(self) -> None:
+        """
+        Test Accept header from Firefox 128
+        """
+        response = self.client.get(
+            self.url,
+            headers={
+                "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/png,image/svg+xml,*/*;q=0.8"  # noqa:E501
+            },
+        )
+        self.assertEqual(response.status_code, 404)
+        self.assertIn("text/html", response.headers["content-type"])

--- a/tbx/core/tests/test_views.py
+++ b/tbx/core/tests/test_views.py
@@ -106,3 +106,28 @@ class TestModeSwitcherView(TestCase):
         # check theme is set on new site
         resp = self.client.get(f"http://{new_site.hostname}/")
         self.assertEqual(resp.context["MODE"], mode)
+
+class PageNotFoundTestCase(TestCase):
+    url = "/does-not-exist/"
+
+    def test_accessible(self) -> None:
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 404)
+        self.assertIn("text/html", response.headers["content-type"])
+
+    def test_accept_html(self) -> None:
+        response = self.client.get(self.url, headers={"Accept": "text/html"})
+        self.assertEqual(response.status_code, 404)
+        self.assertIn("text/html", response.headers["content-type"])
+
+    def test_simple_when_doesnt_accept_html(self) -> None:
+        response = self.client.get(self.url, headers={"Accept": "text/css"})
+        self.assertEqual(response.status_code, 404)
+        self.assertIn("text/plain", response.headers["content-type"])
+
+    def test_simple_when_html_not_highest(self) -> None:
+        response = self.client.get(
+            self.url, headers={"Accept": "text/html;q=0.8,text/css"}
+        )
+        self.assertEqual(response.status_code, 404)
+        self.assertIn("text/plain", response.headers["content-type"])

--- a/tbx/core/utils/views.py
+++ b/tbx/core/utils/views.py
@@ -1,5 +1,6 @@
 from django.http import HttpResponseNotFound, HttpResponseServerError
 from django.views import defaults
+from django.views.decorators.cache import cache_control
 from django.views.decorators.csrf import requires_csrf_token
 from django.views.decorators.vary import vary_on_headers
 
@@ -33,8 +34,9 @@ def show_html_error_page(request):
     return True
 
 
-@vary_on_headers("Accept")
 @requires_csrf_token
+@vary_on_headers("Accept")
+@cache_control(max_age=900)  # 15 minutes
 def page_not_found(
     request, exception=None, template_name="patterns/pages/errors/404.html"
 ):
@@ -47,8 +49,8 @@ def page_not_found(
     )
 
 
-@vary_on_headers("Accept")
 @requires_csrf_token
+@vary_on_headers("Accept")
 def server_error(request, template_name="patterns/pages/errors/500.html"):
     if show_html_error_page(request):
         return defaults.server_error(request, template_name)

--- a/tbx/core/utils/views.py
+++ b/tbx/core/utils/views.py
@@ -1,9 +1,59 @@
+from django.http import HttpResponseNotFound, HttpResponseServerError
 from django.views import defaults
+from django.views.decorators.csrf import requires_csrf_token
+from django.views.decorators.vary import vary_on_headers
 
 
-def page_not_found(request, exception, template_name="patterns/pages/errors/404.html"):
-    return defaults.page_not_found(request, exception, template_name)
+def get_quality(media_type):
+    return float(media_type.params.get("q", 1))
 
 
+def show_html_error_page(request):
+    accepted_types = sorted(request.accepted_types, key=get_quality, reverse=True)
+
+    html_type = next(
+        (
+            accepted_type
+            for accepted_type in accepted_types
+            if accepted_type.match("text/html")
+        ),
+        None,
+    )
+
+    # If HTML isn't accepted, don't serve it
+    if html_type is None:
+        return False
+
+    max_quality = get_quality(accepted_types[0])
+
+    # If HTML isn't the highest quality, don't serve it
+    if get_quality(html_type) < max_quality:
+        return False
+
+    return True
+
+
+@vary_on_headers("Accept")
+@requires_csrf_token
+def page_not_found(
+    request, exception=None, template_name="patterns/pages/errors/404.html"
+):
+    if show_html_error_page(request):
+        return defaults.page_not_found(request, exception, template_name)
+
+    # Serve a simpler, cheaper 404 page if we don't need to
+    return HttpResponseNotFound(
+        "Page not found", content_type="text/plain; charset=utf-8"
+    )
+
+
+@vary_on_headers("Accept")
+@requires_csrf_token
 def server_error(request, template_name="patterns/pages/errors/500.html"):
-    return defaults.server_error(request, template_name)
+    if show_html_error_page(request):
+        return defaults.server_error(request, template_name)
+
+    # Serve a simpler, cheaper 500 page if we don't need to
+    return HttpResponseServerError(
+        "Server error", content_type="text/plain; charset=utf-8"
+    )

--- a/tbx/core/utils/views.py
+++ b/tbx/core/utils/views.py
@@ -10,7 +10,14 @@ def get_quality(media_type):
 
 
 def show_html_error_page(request):
+    # If there is no `Accept` header, serve the simpler page
+    if not request.headers.get("Accept"):
+        return False
+
     accepted_types = sorted(request.accepted_types, key=get_quality, reverse=True)
+
+    if len(accepted_types) == 1 and accepted_types[0].match("*/*"):
+        return False
 
     html_type = next(
         (

--- a/tbx/core/utils/views.py
+++ b/tbx/core/utils/views.py
@@ -50,7 +50,7 @@ def page_not_found(
     if show_html_error_page(request):
         return defaults.page_not_found(request, exception, template_name)
 
-    # Serve a simpler, cheaper 404 page if we don't need to
+    # Serve a simpler, cheaper 404 page if possible
     return HttpResponseNotFound(
         "Page not found", content_type="text/plain; charset=utf-8"
     )
@@ -62,7 +62,7 @@ def server_error(request, template_name="patterns/pages/errors/500.html"):
     if show_html_error_page(request):
         return defaults.server_error(request, template_name)
 
-    # Serve a simpler, cheaper 500 page if we don't need to
+    # Serve a simpler, cheaper 500 page if possible
     return HttpResponseServerError(
         "Server error", content_type="text/plain; charset=utf-8"
     )

--- a/tbx/urls.py
+++ b/tbx/urls.py
@@ -11,6 +11,7 @@ from tbx.core.utils.cache import (
     get_default_cache_control_method_decorator,
 )
 from tbx.core.views import robots, switch_mode
+from tbx.core.utils.views import page_not_found, server_error
 from wagtail import urls as wagtail_urls
 from wagtail.admin import urls as wagtailadmin_urls
 from wagtail.contrib.sitemaps.views import sitemap
@@ -33,7 +34,6 @@ urlpatterns = [
 if settings.DEBUG:
     from django.conf.urls.static import static
     from django.contrib.staticfiles.urls import staticfiles_urlpatterns
-    from django.views.generic import TemplateView
 
     # Serve static and media files from development server
     urlpatterns += staticfiles_urlpatterns()
@@ -42,14 +42,8 @@ if settings.DEBUG:
     # Add views for testing 404 and 500 templates
     urlpatterns += [
         # Add views for testing 404 and 500 templates
-        path(
-            "test404/",
-            TemplateView.as_view(template_name="patterns/pages/errors/404.html"),
-        ),
-        path(
-            "test500/",
-            TemplateView.as_view(template_name="patterns/pages/errors/500.html"),
-        ),
+        path("test404/", page_not_found),
+        path("test500/", server_error),
     ]
 
     # Django Debug Toolbar


### PR DESCRIPTION
### Description of Changes Made

This PR makes 2 notable changes:

#### Serve simpler 404 pages when possible

Our 404 page is a fancy HTML page, comprised of multiple templates, and requiring a number of DB queries to create (not many queries, granted). If a person in a browser loads a page, we want to show them this "fancy" 404 page for a better user experience. However, if the request shouldn't return HTML (eg it's a missing static file) or user never asked for HTML, we shouldn't spend the time creating a fancy 404 page if it's never going to be viewed.

Instead, when possible, we show a simplified HTML page, which just contains text. This requires much fewer resources to generate, and is quicker to serve.

#### Cache 404 pages

This one might be controversial. :grimacing: 

If a page returns a 404, chances are it'll still be a 404 in 10 minutes time, or even longer. Therefore, it's probably something which can be cached to reduce system load.

According to [RFC2616](https://www.w3.org/Protocols/rfc2616/rfc2616-sec13.html#sec13.4), 404s should not be cached. However, for our use case, I think it's worth it. The TTL is intentionally shorter than it probably could be, but this could be increased in future.

In Wagtail, a request will always do a database query. Potentially multiple depending on how much of the path _does_ exist. Therefore, missing pages can result in higher than expected usage, and won't be cached by an edge cache. Worse still, because the 404 pages usually shown are fancy HTML versions, they may do queries in themselves (for eg navigation), making 404s more expensive still.

By caching the 404, we reduce the impact on users viewing it in future, especially useful if a site is being crawled, as many frontend caches will normalise URLs before caching ([ours sure does](https://github.com/torchbox/cloudflare-recipes/blob/master/common-caching.js#L29)).

If a 404 has been cached, and a page is created in its place, Wagtail's existing frontend caching will purge the 404s cache during publishing.

Related reading:

- https://kinsta.com/blog/wordpress-cache/#caching-404-pages
- https://docs.litespeedtech.com/lscache/lscwp/cache/#default-http-status-code-page-ttl
- https://www.drupal.org/project/reuse_cached_404

### How to Test

This can be tested in the browser, by confirming the correct 404 is shown. The unit tests give a few useful examples. Similarly, `curl` can be used to manually exercise the header.

Note: If no `Accept` header is passed, Django assumes `*/*`.

### MR Checklist

- [ ] Add a description of your pull request and instructions for the reviewer to verify your work.
- [ ] If your pull request is for a specific ticket, link to it in the description.
- [ ] Stay on point and keep it small so the merge request can be easily reviewed.
- [ ] Tests and linting passes.

#### Unit tests

- [x] Added
- [ ] Not required

#### Documentation

- [ ] Updated build docs
- [ ] Updated editor guidelines (See https://intranet.torchbox.com/torchbox-com-project-docs for the private link, for Torchbox employees only)
- [ ] Updated field spec (See https://intranet.torchbox.com/torchbox-com-project-docs for the private link, for Torchbox employees only)
- [x] Not required

#### Browser testing

- [ ] I have tested in the following browsers and environments (edit the list as required)
  - Latest version of Chrome on mac
  - Latest version of Firefox on mac
  - Latest version of Safari on mac
  - Safari on last two versions of iOS
  - Chrome on last two versions of Android
- [x] Not required

#### Data protection

- [x] Not relevant
- [ ] This adds new sources of PII and documents it and modifies Birdbath processors accordingly

#### Accessibility

- [ ] Automated WCAG 2.1 tests pass
- [ ] HTML validation passes
- [ ] Manual WCAG 2.1 tests completed
- [ ] I have tested in a screen reader
- [ ] I have tested in high-contrast mode
- [ ] Any animations removed for prefers-reduced-motion
- [ ] Not required

#### Sustainability

- [ ] Images are optimised and lazy-loading used where appropriate
- [ ] SVGs have been optimised
- [x] Perfomance and transfer of data considered
- [ ] If JavaScript is needed alternatives have been considered
- [ ] Not required

#### Pattern library

- [ ] The pattern library component for this template displays correctly, and does not break parent templates
- [ ] The styleguide is updated if relevant
- [x] Changes are not relevant the pattern library

---

I've upstreamed some helper methods which would make this kind of content negotiation much simpler in future: https://github.com/django/django/pull/18415
