### PR TITLE
fix glitch with animation of wagtail bird's head

### DIFF
--- a/tbx/project_styleguide/templates/patterns/atoms/sprites/sprites.html
+++ b/tbx/project_styleguide/templates/patterns/atoms/sprites/sprites.html
@@ -113,7 +113,7 @@
 
     {# for animated wagtail icon - head outline #}
     <symbol id="wagtail-head-outline" viewBox="0 0 80 80">
-        <g style="mix-blend-mode:screen">
+        <g>
             <path d="M49.637 15.035l2.584-4.586C36.2 1.539 25.304 11.977 21.858 18.31L7 43.86v28.826h49.743c7.106-16.378 5.168-26.86-3.23-34.067-6.719-5.765-16.581-5.022-20.673-3.93-1.938-1.529-3.386-8.69 0-14.413 4.652-7.862 13.136-6.77 16.797-5.241z" stroke="var(--color--accent-three)" stroke-width="2" stroke-linejoin="round" fill="none"/>
             <ellipse cx="53.513" cy="24.035" rx="2.584" ry="2.621" fill="var(--color--white)"/>
         </g>


### PR DESCRIPTION
Raised by Alex on slack: https://torchbox.slack.com/archives/C06AQA4D0RX/p1722584827395699

### Description of Changes Made

Issue was with the wagtail animated icon in the showcase bock. In Safari, the body of the wagtail was not visible in light mode, and appeared then disappeared on hover
Fix is to remove the mix-blend-mode from the svg - think this was just an oversight as the other svgs didn't have it any more.

### How to Test

Open the home page on a local build in safari, and check the wagtail bird icon is fully visible in light mode, including when hovering.

### Screenshots

<details>
  <summary>Expand to see more</summary>

</details>

### MR Checklist

- [x] Add a description of your pull request and instructions for the reviewer to verify your work.
- [x] If your pull request is for a specific ticket, link to it in the description.
- [x] Stay on point and keep it small so the merge request can be easily reviewed.
- [x] Tests and linting passes.

#### Unit tests

- [ ] Added
- [x] Not required

#### Documentation

- [ ] Updated build docs
- [ ] Updated editor guidelines (See https://intranet.torchbox.com/torchbox-com-project-docs for the private link, for Torchbox employees only)
- [ ] Updated field spec (See https://intranet.torchbox.com/torchbox-com-project-docs for the private link, for Torchbox employees only)
- [x] Not required

#### Browser testing

- [x] I have tested in the following browsers and environments (edit the list as required)
  - Latest version of Chrome on mac
  - Latest version of Firefox on mac
  - Latest version of Safari on mac
  - Safari on last two versions of iOS
  - Chrome on last two versions of Android
- [ ] Not required

#### Data protection

- [x] Not relevant
- [ ] This adds new sources of PII and documents it and modifies Birdbath processors accordingly

#### Light and dark mode

- [x] I have tested the changes in both light and dark mode
- [ ] The change is not relevant to dark and light mode

#### Accessibility

- [ ] Automated WCAG 2.1 tests pass
- [ ] HTML validation passes
- [ ] Manual WCAG 2.1 tests completed
- [ ] I have tested in a screen reader
- [ ] I have tested in high-contrast mode
- [ ] Any animations removed for prefers-reduced-motion
- [x] Not required

#### Sustainability

- [ ] Images are optimised and lazy-loading used where appropriate
- [ ] SVGs have been optimised
- [ ] Perfomance and transfer of data considered
- [ ] If JavaScript is needed alternatives have been considered
- [x] Not required

#### Pattern library

- [ ] The pattern library component for this template displays correctly, and does not break parent templates
- [ ] The styleguide is updated if relevant
- [x] Changes are not relevant the pattern library
