### PR TITLE
Surface only public and published blog posts on the blog

### DIFF
--- a/tbx/blog/feeds.py
+++ b/tbx/blog/feeds.py
@@ -14,7 +14,7 @@ class BlogFeed(Feed):
     description = "The latest news and views from Torchbox on the work we do, the web and the wider world"
 
     def items(self):
-        return BlogPage.objects.live().order_by("-date")[:10]
+        return BlogPage.objects.public().live().order_by("-date")[:10]
 
     def item_title(self, item):
         return item.title

--- a/tbx/blog/models.py
+++ b/tbx/blog/models.py
@@ -53,7 +53,7 @@ class BlogIndexPage(
         )
         # Get list of blog pages that are descendants of this page
         blog_posts = (
-            BlogPage.objects.live()
+            BlogPage.objects.public().live()
             .descendant_of(self)
             .distinct()
             .prefetch_related(

--- a/tbx/blog/tests/test_models.py
+++ b/tbx/blog/tests/test_models.py
@@ -1,5 +1,10 @@
+from django.core.paginator import Page as PaginatorPage
 from faker import Faker
+from wagtail.coreutils import get_dummy_request
+from wagtail.models import PageViewRestriction
+
 from tbx.blog.factories import BlogIndexPageFactory, BlogPageFactory
+from tbx.blog.models import BlogPage
 from tbx.taxonomy.factories import SectorFactory, ServiceFactory
 from wagtail.test.utils import WagtailPageTestCase
 
@@ -7,8 +12,29 @@ fake = Faker(["en_GB"])
 
 
 class TestBlogIndexPageFactory(WagtailPageTestCase):
-    def test_create(self):
-        BlogIndexPageFactory()
+    @classmethod
+    def setUpTestData(cls):
+        cls.blog_index = BlogIndexPageFactory(title="The Torchbox Blog")
+        cls.blog_post = BlogPageFactory(title="The blog post", parent=cls.blog_index)
+        cls.private_blog_post = BlogPageFactory(title="Private blog post", parent=cls.blog_index)
+        cls.draft_blog_post = BlogPageFactory(title="Draft blog post", live=False, parent=cls.blog_index)
+
+        PageViewRestriction.objects.create(
+            page=cls.private_blog_post, restriction_type="password", password="password123"
+        )
+
+    def test_get_context(self):
+        context = self.blog_index.get_context(get_dummy_request())
+        blog_posts = context["blog_posts"]
+        self.assertIsInstance(blog_posts, PaginatorPage)
+        self.assertEqual(blog_posts.object_list.first(), self.blog_post)
+
+    def test_blog_posts_property(self):
+        """Checks that the blog_posts property returns public and published blog posts under the given blog index."""
+        another_blog = BlogPageFactory(title="Tech blog")
+        BlogPageFactory(title="Tech blog", parent=another_blog)
+
+        self.assertQuerysetEqual(self.blog_index.blog_posts, BlogPage.objects.filter(pk=self.blog_post.pk))
 
 
 class TestBlogPageFactory(WagtailPageTestCase):


### PR DESCRIPTION
Noticed this the other day - the RNIB post was password protected but it appeared in the feed and on the blog index. This PR addresses that