### PR TITLE
TWE-10 - BE - Statistics group block (Division page)

### DIFF
--- a/tbx/core/blocks.py
+++ b/tbx/core/blocks.py
@@ -929,6 +929,7 @@ class NumericStatisticsBlock(blocks.StructBlock):
 
     class Meta:
         icon = "table"
+        label_format = "{headline_number} {description} {further_details}"
 
 
 class NumericStatisticsGroupBlock(blocks.StructBlock):

--- a/tbx/core/blocks.py
+++ b/tbx/core/blocks.py
@@ -931,6 +931,26 @@ class NumericStatisticsBlock(blocks.StructBlock):
         icon = "table"
 
 
+class NumericStatisticsGroupBlock(blocks.StructBlock):
+    title = blocks.CharBlock(max_length=255, required=False)
+    intro = blocks.RichTextBlock(
+        features=settings.NO_HEADING_RICH_TEXT_FEATURES, required=False
+    )
+    statistics = blocks.ListBlock(
+        NumericStatisticsBlock(),
+        max_num=4,
+        min_num=1,
+    )
+
+    class Meta:
+        group = "Custom"
+        icon = "table"
+        label = "Numeric statistics"
+        template = (
+            "patterns/molecules/streamfield/blocks/numeric_stats_group_block.html"
+        )
+
+
 class TextualStatisticsBlock(blocks.StructBlock):
     headline_text = blocks.CharBlock(
         max_length=255,

--- a/tbx/divisions/blocks.py
+++ b/tbx/divisions/blocks.py
@@ -1,6 +1,7 @@
 from tbx.core.blocks import (
     FourPhotoCollageBlock,
     IntroductionWithImagesBlock,
+    NumericStatisticsGroupBlock,
     PartnersBlock,
     StoryBlock,
 )
@@ -9,4 +10,5 @@ from tbx.core.blocks import (
 class DivisionStoryBlock(StoryBlock):
     four_photo_collage = FourPhotoCollageBlock()
     introduction_with_images = IntroductionWithImagesBlock()
+    numeric_statistics = NumericStatisticsGroupBlock()
     partners_block = PartnersBlock()

--- a/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/numeric_stats_group_block.html
+++ b/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/numeric_stats_group_block.html
@@ -1,0 +1,15 @@
+{% load wagtailcore_tags wagtailimages_tags %}
+<div class="grid__division-signpost">
+    {# Section heading #}
+    {% if value.title %}
+        <h2 class="heading heading--two">{{ value.title }}</h2>
+    {% endif %}
+    {# Section intro #}
+    {% if value.intro %}
+        <div class="text text--five division-signpost__intro">{{ value.intro|richtext }}</div>
+    {% endif %}
+    {# Stats #}
+    {# Not sure if the impact report page (which uses stats_numeric.html) should be affected. #}
+    {% include "patterns/molecules/streamfield/blocks/stats_numeric.html" with value=value.statistics %}
+</div>
+

--- a/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/numeric_stats_group_block.yaml
+++ b/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/numeric_stats_group_block.yaml
@@ -1,0 +1,17 @@
+context:
+  value:
+    title: Lighting little fires
+    intro: 'Torchbox has been supporting charities since the start of the digital era. Some of the stats we&apos;re particularly proud of:'
+    statistics:
+      - headline_number: 120
+        description: charities
+        further_details: and counting...
+      - headline_number: 24
+        description: years
+        further_details: working with the sector
+      - headline_number: '263%'
+        description: traffic increase
+        further_details: for an imaginary charity
+      - headline_number: 1
+        description: Guinness record
+        further_details: working with the DEC


### PR DESCRIPTION
[Link to Ticket](https://torchbox.atlassian.net/browse/TWE-10) | Built on top of #324 

### Description of Changes Made

This ticket adds a new block for number statistics from the division page.

FE styling will be a separate PR.

### How to Test

1. Create/Edit a division page.
2. Try to add a new block in the Body field. You should see "Numeric statistics" as a block.
3. Adding the "Numeric statistics" block and filling in the required fields should display the new content on the preview.

### Screenshots

<details><summary>Division page editor</summary>

![image](https://github.com/user-attachments/assets/7fa89851-6808-4a28-824a-3725ae501a95)

![image](https://github.com/user-attachments/assets/a9e71b5d-8862-4dd7-94cf-a8b5a0c764d4)

</details>

### MR Checklist

- [x] Add a description of your pull request and instructions for the reviewer to verify your work.
- [x] If your pull request is for a specific ticket, link to it in the description.
- [x] Stay on point and keep it small so the merge request can be easily reviewed.
- [x] Tests and linting passes.

#### Unit tests

- [ ] Added
- [x] Not required

#### Documentation

- [ ] Updated build docs
- [ ] Updated editor guidelines (See https://intranet.torchbox.com/torchbox-com-project-docs for the private link, for Torchbox employees only)
- [ ] Updated field spec (See https://intranet.torchbox.com/torchbox-com-project-docs for the private link, for Torchbox employees only)
- [ ] Not required

#### Browser testing

- [ ] I have tested in the following browsers and environments (edit the list as required)
  - Latest version of Chrome on mac
  - Latest version of Firefox on mac
  - Latest version of Safari on mac
  - Safari on last two versions of iOS
  - Chrome on last two versions of Android
- [x] Not required

#### Data protection

- [x] Not relevant
- [ ] This adds new sources of PII and documents it and modifies Birdbath processors accordingly

#### Light and dark mode

- [ ] I have tested the changes in both light and dark mode
- [x] The change is not relevant to dark and light mode

#### Accessibility

- [ ] Automated WCAG 2.1 tests pass
- [ ] HTML validation passes
- [ ] Manual WCAG 2.1 tests completed
- [ ] I have tested in a screen reader
- [ ] I have tested in high-contrast mode
- [ ] Any animations removed for prefers-reduced-motion
- [x] Not required

#### Sustainability

- [ ] Images are optimised and lazy-loading used where appropriate
- [ ] SVGs have been optimised
- [ ] Perfomance and transfer of data considered
- [ ] If JavaScript is needed alternatives have been considered
- [x] Not required

#### Pattern library

- [ ] The pattern library component for this template displays correctly, and does not break parent templates
- [ ] The styleguide is updated if relevant
- [x] Changes are not relevant the pattern library
