### PR TITLE
Chore: Update upload-pages-artifact

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Build site (_site directory name is used for Jekyll compatiblity)
         run: mkdocs build --config-file ./mkdocs.yml --site-dir ./_site
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
 
   deploy:
     needs: build


### PR DESCRIPTION
No ticket

### Description of Changes Made

Update `upload-pages-artifact` because `v1` uses a deprecated action.

### Screenshots

<details><summary>The error</summary>

![image](https://github.com/user-attachments/assets/d24fcb69-cdfb-4cab-bf19-83a7441141bf)

</details>

### MR Checklist

- [x] Add a description of your pull request and instructions for the reviewer to verify your work.
- [x] If your pull request is for a specific ticket, link to it in the description.
- [x] Stay on point and keep it small so the merge request can be easily reviewed.
- [x] Tests and linting passes.
