### PR TITLE
TWE-39 Add a new block for textual statistic groups

### DIFF
--- a/tbx/core/blocks.py
+++ b/tbx/core/blocks.py
@@ -1050,11 +1050,21 @@ class NumericStatisticsBlock(blocks.StructBlock):
         label_format = "{headline_number} {description} {further_details}"
 
 
-class NumericStatisticsGroupBlock(blocks.StructBlock):
+class AbstractStatisticsGroupBlock(blocks.StructBlock):
+    """
+    A base class for shared fields between numeric and textual stat blocks.
+    """
+
     title = blocks.CharBlock(max_length=255, required=False)
     intro = blocks.RichTextBlock(
         features=settings.NO_HEADING_RICH_TEXT_FEATURES, required=False
     )
+
+    class Meta:
+        abstract = True
+
+
+class NumericStatisticsGroupBlock(AbstractStatisticsGroupBlock):
     statistics = blocks.ListBlock(
         NumericStatisticsBlock(),
         max_num=4,
@@ -1086,6 +1096,22 @@ class TextualStatisticsBlock(blocks.StructBlock):
 
     class Meta:
         icon = "info-circle"
+
+
+class TextualStatisticsGroupBlock(AbstractStatisticsGroupBlock):
+    statistics = blocks.ListBlock(
+        TextualStatisticsBlock(),
+        max_num=4,
+        min_num=1,
+    )
+
+    class Meta:
+        group = "Custom"
+        icon = "table"
+        label = "Textual statistics"
+        template = (
+            "patterns/molecules/streamfield/blocks/textual_stats_group_block.html"
+        )
 
 
 class TypedTableBlock(blocks.StructBlock):

--- a/tbx/divisions/blocks.py
+++ b/tbx/divisions/blocks.py
@@ -5,6 +5,7 @@ from tbx.core.blocks import (
     NumericStatisticsGroupBlock,
     PartnersBlock,
     StoryBlock,
+    TextualStatisticsGroupBlock,
 )
 
 
@@ -12,5 +13,6 @@ class DivisionStoryBlock(StoryBlock):
     four_photo_collage = FourPhotoCollageBlock()
     introduction_with_images = IntroductionWithImagesBlock()
     numeric_statistics = NumericStatisticsGroupBlock()
+    textual_statistics = TextualStatisticsGroupBlock()
     partners_block = PartnersBlock()
     featured_services = FeaturedServicesBlock()

--- a/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/textual_stats_group_block.html
+++ b/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/textual_stats_group_block.html
@@ -1,0 +1,11 @@
+{% load wagtailcore_tags wagtailimages_tags %}
+<div class="grid__stats-group stats-group">
+    {% if value.title %}
+        <h2 class="motif-heading stats-group__heading">{{ value.title }}</h2>
+    {% endif %}
+    {% if value.intro %}
+        <div class="text text--five stats-group__intro">{{ value.intro|richtext }}</div>
+    {% endif %}
+    {# Stats #}
+    {% include "patterns/molecules/streamfield/blocks/stats_textual.html" with value=value.statistics %}
+</div>

--- a/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/textual_stats_group_block.yml
+++ b/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/textual_stats_group_block.yml
@@ -1,0 +1,9 @@
+context:
+  value:
+    title: Lighting little fires
+    intro: 'Torchbox has been supporting charities since the start of the digital era. Some of the stats we&apos;re particularly proud of:'
+    statistics:
+      - headline_text: Reduction in accessibility issues
+        further_details: '*There might be some sub text here that contextualises this result'
+      - headline_text: General increase in return visitors
+        further_details: '*There might be some sub text here that contextualises this result'

--- a/tbx/project_styleguide/templates/patterns/styleguide/components/components.html
+++ b/tbx/project_styleguide/templates/patterns/styleguide/components/components.html
@@ -115,6 +115,11 @@
         </div>
 
         <div>
+            <h2 class="underline mt-8 mb-2">Textual stats group block</h2>
+            {% include "patterns/molecules/streamfield/blocks/textual_stats_group_block.html" %}
+        </div>
+
+        <div>
             <h2 class="underline mt-8 mb-2">Event block</h2>
             {% include "patterns/molecules/streamfield/blocks/event_block.html" %}
         </div>


### PR DESCRIPTION
[Link to Ticket](https://torchbox.atlassian.net/browse/TWE-39)

### Description of Changes Made

I've created a new block type that's the textual counterpart of the numerical statistics block, and activated it for the division pages.

As suggested in the ticket, the HTML code for this new block was copy/pasted from the numerical stat block added in #328 (with the path to the template adapted).

### How to Test

1. Edit a division page (like `wagtail-test`)
2. In the body, add a "Textual statistics" block
3. Fill in the "title" and "intro" fields, and create one or more "Statistics"
4. Publish the page, then observe that the newly added statistics block is visible

### Screenshots

<details>
  <summary>Expand to see more</summary>

![Screenshot 2025-02-11 at 09-37-30 Editing Division page Wagtail - Wagtail](https://github.com/user-attachments/assets/a1289671-4152-4608-92d5-f7c927e811f7)

![Screenshot 2025-02-11 at 09-36-45 Wagtail Torchbox](https://github.com/user-attachments/assets/b9c7bee0-45c3-4321-825c-23d601fa41ad)


</details>

### MR Checklist

- [x] Add a description of your pull request and instructions for the reviewer to verify your work.
- [x] If your pull request is for a specific ticket, link to it in the description.
- [x] Stay on point and keep it small so the merge request can be easily reviewed.
- [x] Tests and linting passes.

#### Unit tests

- [ ] Added
- [x] Not required

#### Documentation

- [ ] Updated build docs
- [ ] Updated editor guidelines (See https://intranet.torchbox.com/torchbox-com-project-docs for the private link, for Torchbox employees only)
- [x] Updated field spec (See https://intranet.torchbox.com/torchbox-com-project-docs for the private link, for Torchbox employees only)
- [ ] Not required

#### Browser testing

- [x] I have tested in the following browsers and environments (edit the list as required)
  - Latest version of Firefox on Linux
- [ ] Not required

#### Data protection

- [x] Not relevant
- [ ] This adds new sources of PII and documents it and modifies Birdbath processors accordingly

#### Light and dark mode

- [ ] I have tested the changes in both light and dark mode
- [x] The change is not relevant to dark and light mode

#### Accessibility

- [ ] Automated WCAG 2.1 tests pass
- [ ] HTML validation passes
- [ ] Manual WCAG 2.1 tests completed
- [ ] I have tested in a screen reader
- [ ] I have tested in high-contrast mode
- [ ] Any animations removed for prefers-reduced-motion
- [x] Not required

#### Sustainability

- [ ] Images are optimised and lazy-loading used where appropriate
- [ ] SVGs have been optimised
- [ ] Perfomance and transfer of data considered
- [ ] If JavaScript is needed alternatives have been considered
- [x] Not required

#### Pattern library

- [x] The pattern library component for this template displays correctly, and does not break parent templates
- [x] The styleguide is updated if relevant
- [ ] Changes are not relevant the pattern library
