### PR TITLE
Allow moving a HistoricalWorkPage but disable creation

### DIFF
--- a/tbx/work/models.py
+++ b/tbx/work/models.py
@@ -42,7 +42,8 @@ class HistoricalWorkPage(BasePage):
     template = "patterns/pages/work/historical_work_page.html"
 
     # Prevent this page type from being created in Wagtail Admin
-    parent_page_types = []
+    is_creatable = False
+    parent_page_types = ["WorkIndexPage"]
 
     date = models.DateField("Post date", blank=True, null=True)
     body = StreamField(StoryBlock())


### PR DESCRIPTION
No ticket

### Description of Changes Made

Currently, we cannot create nor move historical work pages.

While we still want to keep creation of these page types disabled, we want to be able to move them around to a different work index.

### How to Test

Try to move a historical work page to a different work index page.

### Screenshots

<details><summary>Screen recording</summary>

https://github.com/user-attachments/assets/1319a4a6-bfbb-482e-8152-cf7dc12f65bd

</details>

### MR Checklist

- [x] Add a description of your pull request and instructions for the reviewer to verify your work.
- [x] If your pull request is for a specific ticket, link to it in the description.
- [x] Stay on point and keep it small so the merge request can be easily reviewed.
- [x] Tests and linting passes.

#### Unit tests

- [ ] Added
- [x] Not required

#### Documentation

- [ ] Updated build docs
- [ ] Updated editor guidelines (See https://intranet.torchbox.com/torchbox-com-project-docs for the private link, for Torchbox employees only)
- [ ] Updated field spec (See https://intranet.torchbox.com/torchbox-com-project-docs for the private link, for Torchbox employees only)
- [x] Not required

#### Browser testing

- [ ] I have tested in the following browsers and environments (edit the list as required)
  - Latest version of Chrome on mac
  - Latest version of Firefox on mac
  - Latest version of Safari on mac
  - Safari on last two versions of iOS
  - Chrome on last two versions of Android
- [x] Not required

#### Data protection

- [x] Not relevant
- [ ] This adds new sources of PII and documents it and modifies Birdbath processors accordingly

#### Light and dark mode

- [ ] I have tested the changes in both light and dark mode
- [x] The change is not relevant to dark and light mode

#### Accessibility

- [ ] Automated WCAG 2.1 tests pass
- [ ] HTML validation passes
- [ ] Manual WCAG 2.1 tests completed
- [ ] I have tested in a screen reader
- [ ] I have tested in high-contrast mode
- [ ] Any animations removed for prefers-reduced-motion
- [x] Not required

#### Sustainability

- [ ] Images are optimised and lazy-loading used where appropriate
- [ ] SVGs have been optimised
- [ ] Perfomance and transfer of data considered
- [ ] If JavaScript is needed alternatives have been considered
- [x] Not required

#### Pattern library

- [ ] The pattern library component for this template displays correctly, and does not break parent templates
- [ ] The styleguide is updated if relevant
- [x] Changes are not relevant the pattern library
