### PR TITLE
TWE-26 Make breadcrumb navigation division-aware

### DIFF
--- a/tbx/core/models.py
+++ b/tbx/core/models.py
@@ -146,6 +146,16 @@ class BasePage(
         ]
     )
 
+    @cached_property
+    def breadcrumbs(self):
+        """
+        Return a a list of the current page's ancestors where the first one is
+        either a division page, or the homepage if no ancestor is a division page.
+        """
+        # The homepage has depth=2
+        min_depth = 2 if self.final_division is None else self.final_division.depth
+        return self.get_ancestors().filter(depth__gte=min_depth)
+
 
 class HomePagePartnerLogo(Orderable):
     page = ParentalKey("torchbox.HomePage", related_name="logos")

--- a/tbx/project_styleguide/templates/patterns/navigation/components/breadcrumbs.html
+++ b/tbx/project_styleguide/templates/patterns/navigation/components/breadcrumbs.html
@@ -1,25 +1,23 @@
 {% load wagtailcore_tags %}
 
-{% if page.get_ancestors|length > 1 %}
+{% if page.breadcrumbs %}
     <div class="grid">
         <nav aria-label="breadcrumb" class="breadcrumbs-nav">
             <ul class="breadcrumbs-nav__list">
-                {% with parent_page=page.get_parent %}
-                    {% for ancestor_page in page.get_ancestors %}
-                        {% if not ancestor_page.is_root %}
-                            <li class="breadcrumbs-nav__item {% if ancestor_page == parent_page or ancestor_page.pattern_library_is_parent %}breadcrumbs-nav__item--parent{% else %}breadcrumbs-nav__item--ancestor{% endif %}">
-                                {% if ancestor_page.depth > 2 %}
-                                    <a href="{% pageurl ancestor_page %}" class="breadcrumbs-nav__link">{{ ancestor_page.title }}</a>
-                                {% else %}
-                                    <a class="breadcrumbs-nav__link" href="/">Home</a>
-                                {% endif %}
-                                {% if not forloop.last %}
-                                    <span aria-hidden="true" class="breadcrumbs-nav__divider">/</span>
-                                {% endif %}
-                            </li>
+                {% for crumb in page.breadcrumbs %}
+                    <li class="breadcrumbs-nav__item {% if forloop.last %}breadcrumbs-nav__item--parent{% else %}breadcrumbs-nav__item--ancestor{% endif %}">
+                        <a href="{% pageurl crumb %}" class="breadcrumbs-nav__link">
+                            {% if crumb.depth == 2 %}
+                                Home
+                            {% else %}
+                                {{ crumb.title }}
+                            {% endif %}
+                        </a>
+                        {% if not forloop.last %}
+                            <span aria-hidden="true" class="breadcrumbs-nav__divider">/</span>
                         {% endif %}
-                    {% endfor %}
-                {% endwith %}
+                    </li>
+                {% endfor %}
             </ul>
         </nav>
     </div>

--- a/tbx/project_styleguide/templates/patterns/navigation/components/breadcrumbs.yaml
+++ b/tbx/project_styleguide/templates/patterns/navigation/components/breadcrumbs.yaml
@@ -1,13 +1,11 @@
 context:
   page:
     title: Current page title
-    get_ancestors:
-      - is_root: false
+    breadcrumbs:
+      - depth: 2 # Homepage title is hardcoded in the template
+      - depth: 3
         title: Some category
-      - is_root: false
-        depth: 3
+      - depth: 4
         title: Some sub category
-      - is_root: false
-        depth: 4
+      - depth: 5
         title: We need to go deeper
-        pattern_library_is_parent: True # allows us to set a parent page just in the pattern library


### PR DESCRIPTION
[Link to Ticket](https://torchbox.atlassian.net/browse/TWE-26)

### Description of Changes Made

I changed the breadcumb navigation component so that it's division-aware. That means that if any parent of the page being viewed is a division page, that parent will be used as the root of the breadcrumb navigation (instead of the usual "Home") link.

### How to Test

1) Create a page (any type) that's a child (or grandchild, ...) of a `DivisionPage`
2) Navigate to that new page
3) Observe that the breadcrumbs have the division page as the first element, not the home page as usual

### Screenshots

<details>
  <summary>Expand to see more</summary>

![Screenshot 2025-02-27 at 10-04-25 Asdf Torchbox](https://github.com/user-attachments/assets/c4d5e750-be60-43ad-9eb7-2e316c672e4a)

</details>

### MR Checklist

- [x] Add a description of your pull request and instructions for the reviewer to verify your work.
- [x] If your pull request is for a specific ticket, link to it in the description.
- [x] Stay on point and keep it small so the merge request can be easily reviewed.
- [x] Tests and linting passes.

#### Unit tests

- [ ] Added
- [ ] Not required

#### Documentation

- [ ] Updated build docs
- [ ] Updated editor guidelines (See https://intranet.torchbox.com/torchbox-com-project-docs for the private link, for Torchbox employees only)
- [ ] Updated field spec (See https://intranet.torchbox.com/torchbox-com-project-docs for the private link, for Torchbox employees only)
- [x] Not required

#### Browser testing

- [ ] I have tested in the following browsers and environments (edit the list as required)
  - Latest version of Chrome on mac
  - Latest version of Firefox on mac
  - Latest version of Safari on mac
  - Safari on last two versions of iOS
  - Chrome on last two versions of Android
- [x] Not required

#### Data protection

- [x] Not relevant
- [ ] This adds new sources of PII and documents it and modifies Birdbath processors accordingly

#### Light and dark mode

- [ ] I have tested the changes in both light and dark mode
- [x] The change is not relevant to dark and light mode

#### Accessibility

- [ ] Automated WCAG 2.1 tests pass
- [ ] HTML validation passes
- [ ] Manual WCAG 2.1 tests completed
- [ ] I have tested in a screen reader
- [ ] I have tested in high-contrast mode
- [ ] Any animations removed for prefers-reduced-motion
- [x] Not required

#### Sustainability

- [ ] Images are optimised and lazy-loading used where appropriate
- [ ] SVGs have been optimised
- [ ] Perfomance and transfer of data considered
- [ ] If JavaScript is needed alternatives have been considered
- [x] Not required

#### Pattern library

- [x] The pattern library component for this template displays correctly, and does not break parent templates
- [x] The styleguide is updated if relevant
- [ ] Changes are not relevant the pattern library
