### PR TITLE
Update homepage emissions

### DIFF
--- a/tbx/project_styleguide/templates/patterns/molecules/carbon-impact/carbon-impact.html
+++ b/tbx/project_styleguide/templates/patterns/molecules/carbon-impact/carbon-impact.html
@@ -4,7 +4,7 @@
     <div class="grid">
         <div class="grid__carbon-impact">
             <div class="footer__carbon-impact">
-                <p class="footer__carbon-impact-text">Loading the site homepage emits just <span>0.07g of CO2</span> per view.</p>
+                <p class="footer__carbon-impact-text">Loading the site homepage emits just <span>0.02g of CO2</span> per view.</p>
                 {% if CARBON_EMISSIONS_PAGE %}
                     <p class="footer__carbon-impact-text">
                         <a href="{% pageurl CARBON_EMISSIONS_PAGE %}" class="footer__carbon-impact-link">Find out more about our carbon impact</a>


### PR DESCRIPTION
https://torchbox.com/about/digital-emissions/ is already updated to match. The new homepage is heavier than previously (282kb -> 408kb), but we’re also changing methodologies from SWD v3 to SWD v4, so the carbon emissions are lower. And grid carbon intensity has gone down too.