### PR TITLE
Display current division for primary mobile menu toggle

### DIFF
--- a/tbx/navigation/templatetags/navigation_tags.py
+++ b/tbx/navigation/templatetags/navigation_tags.py
@@ -18,7 +18,7 @@ def primarynav(context):
     }
 
 
-# Primary nav mobile snippet
+# Primary nav mobile snippets
 @register.inclusion_tag(
     "patterns/navigation/components/primary-nav-mobile.html", takes_context=True
 )
@@ -30,6 +30,33 @@ def primarynavmobile(context):
         ].primary_navigation,
         "request": request,
     }
+
+
+@register.simple_tag(name="get_top_level_parent_page", takes_context=True)
+def get_top_level_parent_page(context):
+    # Get all page links from the primary nav.
+    primary_nav = [
+        block.value["page"]
+        for block in context["settings"]["navigation"][
+            "NavigationSettings"
+        ].primary_navigation
+        if block.value.get("page", False)
+    ]
+    # Get all ancestors for this page (highest depth first). Ignores the homepage.
+    ancestors = (
+        context["page"]
+        .get_ancestors(inclusive=True)
+        .filter(depth__gte=3)
+        .order_by("-depth")
+    )
+
+    # If the ancestor is in the primary nav, use that.
+    for ancestor in ancestors:
+        if ancestor in primary_nav:
+            return ancestor
+
+    # If none of the ancestors are in the primary nav, return nothing.
+    return None
 
 
 # Footer nav snippets

--- a/tbx/project_styleguide/templates/patterns/organisms/header/header.html
+++ b/tbx/project_styleguide/templates/patterns/organisms/header/header.html
@@ -23,7 +23,7 @@
                 {% get_top_level_parent_page as parent_page %} {# Get the top-level parent page #}
                 {% firstof parent_page.title "Home" as parent_title %} {# Get the parent's title, or Home if no parent #}
                 <button class="header__primary-menu-toggle" data-primary-mobile-menu-toggle aria-haspopup="true" aria-expanded="false"
-                        aria-label="Mobile menu toggle - currently viewing '{{ parent_title }}'">
+                        aria-label="Mobile menu toggle - currently viewing '{{ parent_title }}' or pages below it">
                     {{ parent_title }}
                     {% include "patterns/atoms/icons/icon.html" with name="chevron" classname="header__primary-menu-toggle-icon" %}
                 </button>

--- a/tbx/project_styleguide/templates/patterns/organisms/header/header.html
+++ b/tbx/project_styleguide/templates/patterns/organisms/header/header.html
@@ -20,13 +20,11 @@
                 </nav>
 
                 {# Primary mobile menu toggle #}
+                {% get_top_level_parent_page as parent_page %} {# Get the top-level parent page #}
+                {% firstof parent_page.title "Home" as parent_title %} {# Get the parent's title, or Home if no parent #}
                 <button class="header__primary-menu-toggle" data-primary-mobile-menu-toggle aria-haspopup="true" aria-expanded="false"
-                        aria-label="Mobile menu toggle - currently viewing '{% if page.final_division %}{{ page.final_division }}{% else %}Home{% endif %}'">
-                    {% if page.final_division %}
-                        {{ page.final_division }}
-                    {% else %}
-                        Home
-                    {% endif %}
+                        aria-label="Mobile menu toggle - currently viewing '{{ parent_title }}'">
+                    {{ parent_title }}
                     {% include "patterns/atoms/icons/icon.html" with name="chevron" classname="header__primary-menu-toggle-icon" %}
                 </button>
 

--- a/tbx/project_styleguide/templates/patterns/organisms/header/header.html
+++ b/tbx/project_styleguide/templates/patterns/organisms/header/header.html
@@ -19,9 +19,14 @@
                     {% endwagtailcache %}
                 </nav>
 
-            {# Primary mobile menu toggle #}
-                <button class="header__primary-menu-toggle" data-primary-mobile-menu-toggle aria-haspopup="true" aria-expanded="false" aria-label="Mobile menu toggle">
-                    Home
+                {# Primary mobile menu toggle #}
+                <button class="header__primary-menu-toggle" data-primary-mobile-menu-toggle aria-haspopup="true" aria-expanded="false"
+                        aria-label="Mobile menu toggle - currently viewing '{% if page.final_division %}{{ page.final_division }}{% else %}Home{% endif %}'">
+                    {% if page.final_division %}
+                        {{ page.final_division }}
+                    {% else %}
+                        Home
+                    {% endif %}
                     {% include "patterns/atoms/icons/icon.html" with name="chevron" classname="header__primary-menu-toggle-icon" %}
                 </button>
 


### PR DESCRIPTION
No ticket

### Description of Changes Made

Update the primary mobile menu toggle label and aria-label to display the relevant divison assigned to a page

### How to Test

### Screenshots

<details>
  <summary>Expand to see more</summary>

</details>

### MR Checklist

- [x] Add a description of your pull request and instructions for the reviewer to verify your work.
- [x] If your pull request is for a specific ticket, link to it in the description.
- [x] Stay on point and keep it small so the merge request can be easily reviewed.
- [x] Tests and linting passes.

#### Unit tests

- [ ] Added
- [x] Not required

#### Documentation

- [ ] Updated build docs
- [ ] Updated editor guidelines (See https://intranet.torchbox.com/torchbox-com-project-docs for the private link, for Torchbox employees only)
- [ ] Updated field spec (See https://intranet.torchbox.com/torchbox-com-project-docs for the private link, for Torchbox employees only)
- [x] Not required

#### Browser testing

- [ ] I have tested in the following browsers and environments (edit the list as required)
  - Latest version of Chrome on mac
  - Latest version of Firefox on mac
  - Latest version of Safari on mac
  - Safari on last two versions of iOS
  - Chrome on last two versions of Android
- [x] Not required

#### Data protection

- [x] Not relevant
- [ ] This adds new sources of PII and documents it and modifies Birdbath processors accordingly

#### Light and dark mode

- [ ] I have tested the changes in both light and dark mode
- [x] The change is not relevant to dark and light mode

#### Accessibility

- [x] Automated WCAG 2.1 tests pass
- [ ] HTML validation passes
- [x] Manual WCAG 2.1 tests completed
- [x] I have tested in a screen reader
- [ ] I have tested in high-contrast mode
- [ ] Any animations removed for prefers-reduced-motion
- [ ] Not required

#### Sustainability

- [ ] Images are optimised and lazy-loading used where appropriate
- [ ] SVGs have been optimised
- [ ] Performance and transfer of data considered
- [ ] If JavaScript is needed alternatives have been considered
- [x] Not required

#### Pattern library

- [ ] The pattern library component for this template displays correctly, and does not break parent templates
- [ ] The styleguide is updated if relevant
- [x] Changes are not relevant the pattern library
