### PR TITLE
TWE-50 Only show division-related content on Work and Blog pages

### DIFF
--- a/tbx/blog/tests/test_models.py
+++ b/tbx/blog/tests/test_models.py
@@ -1,3 +1,5 @@
+from operator import attrgetter
+
 from django.core.paginator import Page as PaginatorPage
 
 from wagtail.coreutils import get_dummy_request
@@ -5,9 +7,11 @@ from wagtail.models import PageViewRestriction
 from wagtail.test.utils import WagtailPageTestCase
 
 from faker import Faker
+from wagtail_factories import PageFactory
 
 from tbx.blog.factories import BlogIndexPageFactory, BlogPageFactory
 from tbx.blog.models import BlogPage
+from tbx.divisions.factories import DivisionPageFactory
 from tbx.taxonomy.factories import SectorFactory, ServiceFactory
 
 
@@ -59,3 +63,31 @@ class TestBlogPageFactory(WagtailPageTestCase):
         )
         self.assertEqual(another_blog_post.related_services.count(), 3)
         self.assertEqual(another_blog_post.related_sectors.count(), 2)
+
+    def test_related_blog_posts_same_division(self):
+        sector = SectorFactory.create()
+        # The logic of `final_division` skips ancestors with depth <= 2,
+        # So we create the division page with enough parents to be at depth 3:
+        division = DivisionPageFactory.create(parent=PageFactory(parent=PageFactory()))
+        blog_post = BlogPageFactory(division=division, related_sectors=[sector])
+        BlogPageFactory(title="same sector", division=None, related_sectors=[sector])
+        BlogPageFactory(
+            title="same division (direct)", division=division, related_sectors=[]
+        )
+        BlogPageFactory(
+            title="same division (direct) same sector",
+            division=division,
+            related_sectors=[sector],
+        )
+        BlogPageFactory(title="same division (parent)", parent=division)
+
+        self.assertQuerySetEqual(
+            blog_post.related_blog_posts,
+            [
+                "same division (direct)",
+                "same division (direct) same sector",
+                "same division (parent)",
+            ],
+            transform=attrgetter("title"),
+            ordered=False,
+        )


### PR DESCRIPTION
[Link to Ticket](https://torchbox.atlassian.net/browse/TWE-50)

### Description of Changes Made

Changed the logic of `related_blog_posts` (resp. `related_works`) for `BlogPage` (resp. `WorkPage`) to take the page's `final_division` into account. If the page is associated with a division, then only blog posts (resp. work pages) will be displayed under the "More" heading on the page.

### How to Test

See testing notes on [ticket](https://torchbox.atlassian.net/browse/TWE-50)

### Screenshots

I ran out of time for screenshots, sorry (I'm struggling to get the right type of pages set up locally to demonstrate the issue, but I hope the unit tests added will demonstrate the fix well enough).


### MR Checklist

- [x] Add a description of your pull request and instructions for the reviewer to verify your work.
- [x] If your pull request is for a specific ticket, link to it in the description.
- [x] Stay on point and keep it small so the merge request can be easily reviewed.
- [x] Tests and linting passes.

#### Unit tests

- [x] Added
- [ ] Not required

#### Documentation

- [ ] Updated build docs
- [ ] Updated editor guidelines (See https://intranet.torchbox.com/torchbox-com-project-docs for the private link, for Torchbox employees only)
- [ ] Updated field spec (See https://intranet.torchbox.com/torchbox-com-project-docs for the private link, for Torchbox employees only)
- [x] Not required

#### Browser testing

- [ ] I have tested in the following browsers and environments (edit the list as required)
  - Latest version of Chrome on mac
  - Latest version of Firefox on mac
  - Latest version of Safari on mac
  - Safari on last two versions of iOS
  - Chrome on last two versions of Android
- [ ] Not required

#### Data protection

- [x] Not relevant
- [ ] This adds new sources of PII and documents it and modifies Birdbath processors accordingly

#### Light and dark mode

- [ ] I have tested the changes in both light and dark mode
- [x] The change is not relevant to dark and light mode

#### Accessibility

- [ ] Automated WCAG 2.1 tests pass
- [ ] HTML validation passes
- [ ] Manual WCAG 2.1 tests completed
- [ ] I have tested in a screen reader
- [ ] I have tested in high-contrast mode
- [ ] Any animations removed for prefers-reduced-motion
- [x] Not required

#### Sustainability

- [ ] Images are optimised and lazy-loading used where appropriate
- [ ] SVGs have been optimised
- [x] Performance and transfer of data considered
- [ ] If JavaScript is needed alternatives have been considered
- [ ] Not required

#### Pattern library

- [ ] The pattern library component for this template displays correctly, and does not break parent templates
- [ ] The styleguide is updated if relevant
- [x] Changes are not relevant the pattern library
