### PR TITLE
Fix: Check first if the page exists in the context

### DIFF
--- a/tbx/navigation/templatetags/navigation_tags.py
+++ b/tbx/navigation/templatetags/navigation_tags.py
@@ -34,6 +34,10 @@ def primarynavmobile(context):
 
 @register.simple_tag(name="get_top_level_parent_page", takes_context=True)
 def get_top_level_parent_page(context):
+    # Exit immediately if there is there's no data available.
+    if "page" not in context or "settings" not in context:
+        return None
+
     # Get all page links from the primary nav.
     primary_nav = [
         block.value["page"]

--- a/tbx/project_styleguide/templates/patterns/organisms/header/header.html
+++ b/tbx/project_styleguide/templates/patterns/organisms/header/header.html
@@ -20,8 +20,16 @@
                 </nav>
 
                 {# Primary mobile menu toggle #}
-                <button class="header__primary-menu-toggle" data-primary-mobile-menu-toggle aria-haspopup="true" aria-expanded="false" aria-label="Mobile menu toggle">
-                    Home
+                {% get_top_level_parent_page as parent_page %} {# Get the top-level parent page #}
+                {% firstof parent_page.title "Home" as parent_title %} {# Get the parent's title, or Home if no parent #}
+                <button
+                    aria-expanded="false"
+                    aria-haspopup="true"
+                    aria-label="Mobile menu toggle - currently viewing '{{ parent_title }}' or pages below it"
+                    class="header__primary-menu-toggle"
+                    data-primary-mobile-menu-toggle
+                >
+                    {{ parent_title }}
                     {% include "patterns/atoms/icons/icon.html" with name="chevron" classname="header__primary-menu-toggle-icon" %}
                 </button>
 


### PR DESCRIPTION
Link to Ticket

### Description of Changes Made

Fix for the recent errors. The 404 error page calls the `get_top_level_parent_page` tag which tries to access the key `page` in the context.

### How to Test

Try to trigger a 404 page with a nonexistent URL. (Make sure `DEBUG = False` is set in your `tbx/settings/local.py` file.)

### Screenshots

<details>
  <summary>Before</summary>

<img width="749" alt="image" src="https://github.com/user-attachments/assets/f86ae136-1ae2-4048-9f57-7680bddcc203" />

</details>

<details>
  <summary>After</summary>

<img width="749" alt="image" src="https://github.com/user-attachments/assets/548f2f2b-c951-4009-bbfc-551e424b19e5" />

</details>

### MR Checklist

- [ ] Add a description of your pull request and instructions for the reviewer to verify your work.
- [ ] If your pull request is for a specific ticket, link to it in the description.
- [ ] Stay on point and keep it small so the merge request can be easily reviewed.
- [ ] Tests and linting passes.

#### Unit tests

- [ ] Added
- [ ] Not required

#### Documentation

- [ ] Updated build docs
- [ ] Updated editor guidelines (See https://intranet.torchbox.com/torchbox-com-project-docs for the private link, for Torchbox employees only)
- [ ] Updated field spec (See https://intranet.torchbox.com/torchbox-com-project-docs for the private link, for Torchbox employees only)
- [ ] Not required

#### Browser testing

- [ ] I have tested in the following browsers and environments (edit the list as required)
  - Latest version of Chrome on mac
  - Latest version of Firefox on mac
  - Latest version of Safari on mac
  - Safari on last two versions of iOS
  - Chrome on last two versions of Android
- [ ] Not required

#### Data protection

- [ ] Not relevant
- [ ] This adds new sources of PII and documents it and modifies Birdbath processors accordingly

#### Light and dark mode

- [ ] I have tested the changes in both light and dark mode
- [ ] The change is not relevant to dark and light mode

#### Accessibility

- [ ] Automated WCAG 2.1 tests pass
- [ ] HTML validation passes
- [ ] Manual WCAG 2.1 tests completed
- [ ] I have tested in a screen reader
- [ ] I have tested in high-contrast mode
- [ ] Any animations removed for prefers-reduced-motion
- [ ] Not required

#### Sustainability

- [ ] Images are optimised and lazy-loading used where appropriate
- [ ] SVGs have been optimised
- [ ] Performance and transfer of data considered
- [ ] If JavaScript is needed alternatives have been considered
- [ ] Not required

#### Pattern library

- [ ] The pattern library component for this template displays correctly, and does not break parent templates
- [ ] The styleguide is updated if relevant
- [ ] Changes are not relevant the pattern library
