### PR TITLE
Fix slow blog posts

### DIFF
--- a/tbx/taxonomy/tests/test_models.py
+++ b/tbx/taxonomy/tests/test_models.py
@@ -1,3 +1,5 @@
+from unittest import skip
+
 from wagtail.models import Site
 from wagtail.test.utils import WagtailPageTestCase
 
@@ -78,6 +80,7 @@ class TestTaxonomies(WagtailPageTestCase):
         self.assertListEqual(list(self.blog_page_service.tags), [services[1]])
         self.assertListEqual(list(self.blog_page_sector.tags), [sectors[1]])
 
+    @skip("Related services in blog posts are currently disabled")
     def test_related_blog_posts_services(self):
         """
         Tests the `related_blog_posts` property on the `BlogPage` model using the Service taxonomy
@@ -104,6 +107,7 @@ class TestTaxonomies(WagtailPageTestCase):
         # so there should be 3 related blog posts
         self.assertEqual(len(blog_post3.related_blog_posts), 3)
 
+    @skip("Related sectors in blog posts are currently disabled")
     def test_related_blog_posts_sectors(self):
         """
         Tests the `related_blog_posts` property on the `BlogPage` model using the Sectors taxonomy


### PR DESCRIPTION
[Link to Ticket]()

### Description of Changes Made

Blog posts and work pages are slow to load.

This tweak makes the assumptions that:

- there is only one blog index page per division,
- there is only one work index page per division, and
- there is no individual blog post and work page that is pointed at a division that isn't its own ancestor. (e.g. it's under the Charity division but the `division` field says "Public")

This MR also removes all links to the related sectors and services. (Ideally, we'd boost pages with related services, but that needs a bit of thinking, as Baptiste pointed out in the previous MR.)

### How to Test

1. Check the blog posts load faster and load okay
2. Check the work pages load faster and load okay

### Screenshots

### MR Checklist

- [ ] Add a description of your pull request and instructions for the reviewer to verify your work.
- [ ] If your pull request is for a specific ticket, link to it in the description.
- [ ] Stay on point and keep it small so the merge request can be easily reviewed.
- [ ] Tests and linting passes.

#### Unit tests

- [ ] Added
- [ ] Not required

#### Documentation

- [ ] Updated build docs
- [ ] Updated editor guidelines (See https://intranet.torchbox.com/torchbox-com-project-docs for the private link, for Torchbox employees only)
- [ ] Updated field spec (See https://intranet.torchbox.com/torchbox-com-project-docs for the private link, for Torchbox employees only)
- [ ] Not required

#### Browser testing

- [ ] I have tested in the following browsers and environments (edit the list as required)
  - Latest version of Chrome on mac
  - Latest version of Firefox on mac
  - Latest version of Safari on mac
  - Safari on last two versions of iOS
  - Chrome on last two versions of Android
- [ ] Not required

#### Data protection

- [ ] Not relevant
- [ ] This adds new sources of PII and documents it and modifies Birdbath processors accordingly

#### Light and dark mode

- [ ] I have tested the changes in both light and dark mode
- [ ] The change is not relevant to dark and light mode

#### Accessibility

- [ ] Automated WCAG 2.1 tests pass
- [ ] HTML validation passes
- [ ] Manual WCAG 2.1 tests completed
- [ ] I have tested in a screen reader
- [ ] I have tested in high-contrast mode
- [ ] Any animations removed for prefers-reduced-motion
- [ ] Not required

#### Sustainability

- [ ] Images are optimised and lazy-loading used where appropriate
- [ ] SVGs have been optimised
- [ ] Performance and transfer of data considered
- [ ] If JavaScript is needed alternatives have been considered
- [ ] Not required

#### Pattern library

- [ ] The pattern library component for this template displays correctly, and does not break parent templates
- [ ] The styleguide is updated if relevant
- [ ] Changes are not relevant the pattern library
