### PR TITLE
TWE-62: Add PromoBlock to ServiceAreaPage (with link optional)

### DIFF
--- a/tbx/core/blocks.py
+++ b/tbx/core/blocks.py
@@ -209,7 +209,10 @@ class VideoBlock(blocks.StructBlock):
 
 class ButtonLinkStructValue(blocks.StructValue):
     def get_button_link_block(self):
-        return self.get("button_link")[0]
+        try:
+            return self.get("button_link")[0]
+        except IndexError:
+            return None
 
     # return an href-ready value for button_link
     def get_button_link(self):

--- a/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/promo_block.html
+++ b/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/promo_block.html
@@ -4,7 +4,9 @@
     <div class="promo-block__content">
         {% include "patterns/atoms/section-title/section-title.html" with title=value.title classes="promo-block__title" %}
         <p class="promo-block__description">{{ value.description }}</p>
-        <a href="{{ value.get_button_link }}" class="button promo-block__button">{{ value.button_text }}</a>
+        {% if value.button_text %}
+            <a href="{{ value.get_button_link }}" class="button promo-block__button">{{ value.button_text }}</a>
+        {% endif %}
         {% if value.secondary_link %}
             <hr class="promo-block__divider" aria-hidden="true" />
             {% with secondary_link=value.secondary_link.0.value %}

--- a/tbx/services/tests/test_blocks.py
+++ b/tbx/services/tests/test_blocks.py
@@ -1,0 +1,45 @@
+from django.test import SimpleTestCase
+
+from wagtail.blocks import StructBlockValidationError
+
+from tbx.services.blocks import OptionalLinkPromoBlock, PromoBlock
+
+
+class OptionalLinkPromoBlockTestCase(SimpleTestCase):
+    def test_basic_promo_block_button_link_required(self):
+        try:
+            PromoBlock().clean({"button_link": []})
+        except StructBlockValidationError:
+            pass
+        else:
+            self.fail("PromoBlock.button_link should be required")
+
+    def test_custom_promo_block_button_link_optional(self):
+        try:
+            OptionalLinkPromoBlock().clean({"button_link": []})
+        except StructBlockValidationError as e:
+            self.fail(e.as_json_data())
+
+    def test_basic_promo_block_button_text_required(self):
+        try:
+            PromoBlock().clean({"button_text": ""})
+        except StructBlockValidationError:
+            pass
+        else:
+            self.fail("PromoBlock.button_text should be required")
+
+    def test_custom_promo_block_button_text_optional(self):
+        try:
+            OptionalLinkPromoBlock().clean({"button_text": ""})
+        except StructBlockValidationError as e:
+            self.fail(e.as_json_data())
+
+    def test_custom_promo_block_link_required_if_text_provided(self):
+        try:
+            OptionalLinkPromoBlock().clean({"button_text": "test", "button_link": []})
+        except StructBlockValidationError:
+            pass
+        else:
+            self.fail(
+                "PromoBlock.button_link should be required if button_text is provided"
+            )


### PR DESCRIPTION
[Link to Ticket](https://torchbox.atlassian.net/browse/TWE-62)

### Description of Changes Made

This PR adds a `PromoBlock` to the `ServiceAreaPage` page type. Unlike the core `PromoBlock`, this custom one doesn't require the editor to provide a `link_text` or  a `link_button`. Note however that if a `link_text` is provided, then `link_button` is required.

### How to Test

1) Create (or edit) a `ServiceAreaPage`
2) In the `body` field, add a "Promo" block
3) Observe that neither "Link text" nor "Link Button" are marked as required
4) Publish the page and view it
5) See that the promo block is visible, but it has no button

### Screenshots

<details>
  <summary>The admin side:</summary>

![Screenshot 2025-04-14 at 11-57-32 Editing Service area page Advocacy Engagement   Income - Wagtail](https://github.com/user-attachments/assets/bc0583a5-49c4-4626-aa7e-86fd498c08b2)


</details>

<details>
<summary>The resulting page</summary>

![Screenshot 2025-04-14 at 11-57-08 Advocacy Engagement   Income Torchbox](https://github.com/user-attachments/assets/74b154a2-a5dd-4f39-a382-fa09f88fa423)


</details>

### MR Checklist

- [x] Add a description of your pull request and instructions for the reviewer to verify your work.
- [x] If your pull request is for a specific ticket, link to it in the description.
- [x] Stay on point and keep it small so the merge request can be easily reviewed.
- [x] Tests and linting passes.

#### Unit tests

- [x] Added
- [ ] Not required

#### Documentation

- [ ] Updated build docs
- [ ] Updated editor guidelines (See https://intranet.torchbox.com/torchbox-com-project-docs for the private link, for Torchbox employees only)
- [x] ⚠️ Updated field spec (See https://intranet.torchbox.com/torchbox-com-project-docs for the private link, for Torchbox employees only)  **This needs to be done once PR has been approved**
- [ ] Not required

#### Browser testing

- [ ] I have tested in the following browsers and environments (edit the list as required)
  - Latest version of Chrome on mac
  - Latest version of Firefox on mac
  - Latest version of Safari on mac
  - Safari on last two versions of iOS
  - Chrome on last two versions of Android
- [x] Not required

#### Data protection

- [x] Not relevant
- [ ] This adds new sources of PII and documents it and modifies Birdbath processors accordingly

#### Light and dark mode

- [ ] I have tested the changes in both light and dark mode
- [x] The change is not relevant to dark and light mode

#### Accessibility

- [ ] Automated WCAG 2.1 tests pass
- [ ] HTML validation passes
- [ ] Manual WCAG 2.1 tests completed
- [ ] I have tested in a screen reader
- [ ] I have tested in high-contrast mode
- [ ] Any animations removed for prefers-reduced-motion
- [x] Not required

#### Sustainability

- [ ] Images are optimised and lazy-loading used where appropriate
- [ ] SVGs have been optimised
- [ ] Performance and transfer of data considered
- [ ] If JavaScript is needed alternatives have been considered
- [x] Not required

#### Pattern library

- [x] The pattern library component for this template displays correctly, and does not break parent templates
- [ ] The styleguide is updated if relevant
- [ ] Changes are not relevant the pattern library
