### PR TITLE
TWE 63 render paragraphs for promo block descriptions

### DIFF
--- a/tbx/core/blocks.py
+++ b/tbx/core/blocks.py
@@ -841,7 +841,7 @@ class EventBlock(BaseEventBlock):
 
 class PromoBlock(blocks.StructBlock):
     title = blocks.TextBlock()
-    description = blocks.TextBlock()
+    description = blocks.RichTextBlock(features=settings.NO_HEADING_RICH_TEXT_FEATURES)
     image = CustomImageChooserBlock()
     button_text = blocks.CharBlock(max_length=55)
     button_link = blocks.StreamBlock(

--- a/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/promo_block.html
+++ b/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/promo_block.html
@@ -1,9 +1,9 @@
-{% load wagtailimages_tags %}
+{% load wagtailcore_tags wagtailimages_tags %}
 
 <div class="grid__promo promo-block">
     <div class="promo-block__content">
         {% include "patterns/atoms/section-title/section-title.html" with title=value.title classes="promo-block__title" %}
-        <p class="promo-block__description">{{ value.description }}</p>
+        <div class="rich-text promo-block__description">{{ value.description|richtext }}</div>
         {% if value.button_text %}
             <a href="{{ value.get_button_link }}" class="button promo-block__button">{{ value.button_text }}</a>
         {% endif %}

--- a/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/promo_block.yaml
+++ b/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/promo_block.yaml
@@ -1,7 +1,11 @@
 context:
   value:
     title: This is the title of this generic promo teaser
-    description: Donec tortor mi, pulvinar non enim et, hendrerit efficitur nisi. Etiam egestas imperdiet purus, faucibus convallis leo pharetra sit amet.
+    description: |
+      Donec tortor mi, pulvinar non enim et, hendrerit efficitur nisi. Etiam egestas imperdiet purus, faucibus convallis leo pharetra sit amet.
+      Sapiente eos et repudiandae amet consequatur.
+
+      Fugiat quia eaque enim itaque cupiditate animi blanditiis. Quas at et id magnam impedit.
     button_text: Call to action
     get_button_link: '/#'
     secondary_link:


### PR DESCRIPTION
[Link to Ticket](https://torchbox.atlassian.net/browse/TWE-63)

### Description of Changes Made

Add support for paragraphs in `PromoBlock.description`

### How to Test

1) Create (or edit) a page with a `PromoBlock` (like a `ServiceAreaPage` for example)
2) Edit the "body" field to add a new "Promo" block
3) In the "description" field, enter several paragraphs
4) Save and view the page, observe that the paragraphs are visible (not just a single block of text)

### Screenshots

<details>
  <summary>Expand to see more</summary>

![Screenshot 2025-04-17 at 10-38-32 Advocacy Engagement   Income Torchbox](https://github.com/user-attachments/assets/8269f36a-6a7a-47ff-948f-3d89bcec5dac)


</details>

### MR Checklist

- [x] Add a description of your pull request and instructions for the reviewer to verify your work.
- [x] If your pull request is for a specific ticket, link to it in the description.
- [x] Stay on point and keep it small so the merge request can be easily reviewed.
- [x] Tests and linting passes.

#### Unit tests

- [ ] Added
- [x] Not required

#### Documentation

- [ ] Updated build docs
- [ ] Updated editor guidelines (See https://intranet.torchbox.com/torchbox-com-project-docs for the private link, for Torchbox employees only)
- [ ] Updated field spec (See https://intranet.torchbox.com/torchbox-com-project-docs for the private link, for Torchbox employees only)
- [x] Not required

#### Browser testing

- [ ] I have tested in the following browsers and environments (edit the list as required)
  - Latest version of Chrome on mac
  - Latest version of Firefox on mac
  - Latest version of Safari on mac
  - Safari on last two versions of iOS
  - Chrome on last two versions of Android
- [x] Not required

#### Data protection

- [x] Not relevant
- [ ] This adds new sources of PII and documents it and modifies Birdbath processors accordingly

#### Light and dark mode

- [ ] I have tested the changes in both light and dark mode
- [x] The change is not relevant to dark and light mode

#### Accessibility

- [ ] Automated WCAG 2.1 tests pass
- [ ] HTML validation passes
- [ ] Manual WCAG 2.1 tests completed
- [ ] I have tested in a screen reader
- [ ] I have tested in high-contrast mode
- [ ] Any animations removed for prefers-reduced-motion
- [x] Not required

#### Sustainability

- [ ] Images are optimised and lazy-loading used where appropriate
- [ ] SVGs have been optimised
- [ ] Performance and transfer of data considered
- [ ] If JavaScript is needed alternatives have been considered
- [x] Not required

#### Pattern library

- [x] The pattern library component for this template displays correctly, and does not break parent templates
- [ ] The styleguide is updated if relevant
- [ ] Changes are not relevant the pattern library
