### PR TITLE
Add partners_block to ServiceAreaStoryBlock

### DIFF
--- a/tbx/project_styleguide/templates/patterns/_pattern_library_only/streamfield/service_area_story_container.html
+++ b/tbx/project_styleguide/templates/patterns/_pattern_library_only/streamfield/service_area_story_container.html
@@ -1,4 +1,4 @@
-
+{% include "patterns/molecules/streamfield/blocks/partners_block.html" %}
 {% include "patterns/molecules/streamfield/blocks/four_photo_collage_block.html" %}
 {% include "patterns/molecules/streamfield/blocks/icon_keypoints_block.html" %}
 {% include "patterns/molecules/streamfield/blocks/contact_call_to_action.html" %}

--- a/tbx/project_styleguide/templates/patterns/_pattern_library_only/streamfield/service_area_story_container.yaml
+++ b/tbx/project_styleguide/templates/patterns/_pattern_library_only/streamfield/service_area_story_container.yaml
@@ -48,3 +48,11 @@ tags:
       raw:
         alt: 'mobile image retina'
         url: 'https://picsum.photos/740/670.webp'
+    partner_logo max-107x107 format-webp as partner_logo_image:
+      target_var: partner_logo_image
+      raw:
+        url: 'https://picsum.photos/107/107.webp'
+    partner_logo max-214x214 format-webp as partner_logo_image_retina:
+      target_var: partner_logo_image_retina
+      raw:
+        url: 'https://picsum.photos/214/214.webp'

--- a/tbx/services/blocks.py
+++ b/tbx/services/blocks.py
@@ -94,6 +94,7 @@ class OptionalLinkPromoBlock(PromoBlock):
 
 
 class ServiceAreaStoryBlock(StoryBlock):
+    partners_block = PartnersBlock()
     blog_chooser = BlogChooserBlock()
     four_photo_collage = FourPhotoCollageBlock()
     key_points = IconKeyPointsBlock(label="Key points with icons")


### PR DESCRIPTION
Monday Ticket - [Link to ticket](https://torchbox.monday.com/boards/1143413211/pulses/1960225834)
Jira Ticket - [Link to Ticket](https://torchbox.atlassian.net/browse/TMI-44)

### Description of Changes Made

Added the partners_block to ServiceAreaStoryBlock so editors can use this block on the Service Area Page. Additionally updated the pattern library.

### How to Test

1. Build the project locally as per the README and pull the sites staging data
2. Navigate to an existing [Service Area Page](http://127.0.0.1:8000/admin/pages/2560/edit/)
3. Add a new Partner Logos block in the page body and populate the block with a tile and some images.
4. Preview the page to ensure you can preview the partner logos.
5. Publish the page and view the local live version to ensure the logos appear as expected.

### Screenshots

<details>
  <summary>Dark mode</summary>

![Screenshot from 2025-05-19 12-34-43](https://github.com/user-attachments/assets/6ab786b5-965e-4213-9968-8f96b0c1a2e1)

</details>

<details><summary>Light mode</summary>

![Screenshot from 2025-05-19 12-34-49](https://github.com/user-attachments/assets/0a2394f4-2336-4f7b-8060-7da040d1ba97)

</details> 

### MR Checklist

- [x] Add a description of your pull request and instructions for the reviewer to verify your work.
- [x] If your pull request is for a specific ticket, link to it in the description.
- [x] Stay on point and keep it small so the merge request can be easily reviewed.
- [x] Tests and linting passes.

#### Unit tests

- [ ] Added
- [x] Not required

#### Documentation

- [ ] Updated build docs
- [ ] Updated editor guidelines (See https://intranet.torchbox.com/torchbox-com-project-docs for the private link, for Torchbox employees only)
- [ ] Updated field spec (See https://intranet.torchbox.com/torchbox-com-project-docs for the private link, for Torchbox employees only)
- [x] Not required

#### Browser testing

- [ ] I have tested in the following browsers and environments (edit the list as required)
  - Latest version of Chrome on mac
  - Latest version of Firefox on mac
  - Latest version of Safari on mac
  - Safari on last two versions of iOS
  - Chrome on last two versions of Android
- [x] Not required

#### Data protection

- [x] Not relevant
- [ ] This adds new sources of PII and documents it and modifies Birdbath processors accordingly

#### Light and dark mode

- [x] I have tested the changes in both light and dark mode
- [ ] The change is not relevant to dark and light mode

#### Accessibility

- [ ] Automated WCAG 2.1 tests pass
- [ ] HTML validation passes
- [ ] Manual WCAG 2.1 tests completed
- [ ] I have tested in a screen reader
- [ ] I have tested in high-contrast mode
- [ ] Any animations removed for prefers-reduced-motion
- [x] Not required

#### Sustainability

- [ ] Images are optimised and lazy-loading used where appropriate
- [ ] SVGs have been optimised
- [ ] Performance and transfer of data considered
- [ ] If JavaScript is needed alternatives have been considered
- [x] Not required

#### Pattern library

- [ ] The pattern library component for this template displays correctly, and does not break parent templates
- [x] The styleguide is updated if relevant
- [ ] Changes are not relevant the pattern library
