### PR TITLE
TMI 48 - Add featured services block to service area page

### DIFF
--- a/tbx/core/blocks.py
+++ b/tbx/core/blocks.py
@@ -324,6 +324,14 @@ class FeaturedServicesBlock(blocks.StructBlock):
         template = "patterns/molecules/streamfield/blocks/featured_services_block.html"
 
 
+class ServiceAreaFeaturedServicesBlock(FeaturedServicesBlock):
+    cards = blocks.ListBlock(
+        FeaturedPageCardBlock(),
+        max_num=8,
+        min_num=6,
+    )
+
+
 class FourPhotoCollageBlock(blocks.StructBlock):
     """
     Accepts 4 photos shown as a collage + text below.

--- a/tbx/core/blocks.py
+++ b/tbx/core/blocks.py
@@ -1,4 +1,4 @@
-from collections import defaultdict
+from collections import OrderedDict, defaultdict
 from datetime import datetime
 import logging
 
@@ -307,6 +307,10 @@ class FeaturedPageCardBlock(blocks.StructBlock):
         icon = "breadcrumb-expand"
 
 
+class ServiceAreaFeaturedPageCardBlock(FeaturedPageCardBlock):
+    image = ImageChooserBlock(required=False)
+
+
 class FeaturedServicesBlock(blocks.StructBlock):
     title = blocks.CharBlock(max_length=255, required=False)
     intro = blocks.RichTextBlock(
@@ -325,8 +329,24 @@ class FeaturedServicesBlock(blocks.StructBlock):
 
 
 class ServiceAreaFeaturedServicesBlock(FeaturedServicesBlock):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Get all child blocks
+        child_blocks = self.child_blocks
+        # Define the desired order of fields
+        field_order = ['title', 'intro', 'should_display_images', 'cards']
+        # Create new OrderedDict with fields in desired order
+        self.child_blocks = OrderedDict([
+            (name, child_blocks[name]) for name in field_order
+        ])
+        
+    should_display_images = blocks.BooleanBlock(
+        default=True,
+        help_text="Hide images from all cards when unchecked",
+        required=False,
+    )
     cards = blocks.ListBlock(
-        FeaturedPageCardBlock(),
+        ServiceAreaFeaturedPageCardBlock(),
         max_num=8,
         min_num=6,
     )

--- a/tbx/core/blocks.py
+++ b/tbx/core/blocks.py
@@ -334,12 +334,12 @@ class ServiceAreaFeaturedServicesBlock(FeaturedServicesBlock):
         # Get all child blocks
         child_blocks = self.child_blocks
         # Define the desired order of fields
-        field_order = ['title', 'intro', 'should_display_images', 'cards']
+        field_order = ["title", "intro", "should_display_images", "cards"]
         # Create new OrderedDict with fields in desired order
-        self.child_blocks = OrderedDict([
-            (name, child_blocks[name]) for name in field_order
-        ])
-        
+        self.child_blocks = OrderedDict(
+            [(name, child_blocks[name]) for name in field_order]
+        )
+
     should_display_images = blocks.BooleanBlock(
         default=True,
         help_text="Hide images from all cards when unchecked",

--- a/tbx/core/templatetags/util_tags.py
+++ b/tbx/core/templatetags/util_tags.py
@@ -86,6 +86,12 @@ def format_date_for_event(start_date, start_time=None, end_date=None, end_time=N
     return formatted_start_date
 
 
+@register.simple_tag
+def check_all_cards_have_images(cards):
+    """Check if all cards have images."""
+    return all(bool(card.get("image", None)) for card in cards)
+
+
 @register.filter(name="ifinlist")
 def ifinlist(value, list):
     # cast to strings before testing as this is used for heading levels 2, 3, 4 etc

--- a/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/featured_services_block.html
+++ b/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/featured_services_block.html
@@ -1,4 +1,5 @@
-{% load wagtailcore_tags wagtailimages_tags %}
+{% load wagtailcore_tags wagtailimages_tags util_tags %}
+{% check_all_cards_have_images value.cards as show_images %}
 <div class="grid__featured-services featured-services">
     <div class="featured-services__header">
         <h2 class="motif-heading motif-heading--half-width">{{ value.title }}</h2>
@@ -9,7 +10,13 @@
     <ul class="featured-services__cards">
         {% for card in value.cards %}
             <li class="featured-services__card">
-                {% srcset_image card.image format-webp fill-{750x420,650x420} sizes="(max-width: 750px) 100vw, (min-width: 751px) 650px" alt="" %}
+                {# The ServiceAreaFeaturedServicesBlock supports optional image display, other blocks always show images #}
+                {% if value.should_display_images or value.should_display_images is None %}
+                {# Images are optional in the ServiceAreaFeaturedServicesBlock, if one image is not set, do not show for any card #}
+                    {% if show_images %}
+                        {% srcset_image card.image format-webp fill-{750x420,650x420} sizes="(max-width: 750px) 100vw, (min-width: 751px) 650px" alt="" %}
+                    {% endif %}
+                {% endif %}
                 <div class="featured-services__text">
                     <h3 class="featured-services__heading heading heading--two-b{% if value.cards|length >= 4 %} heading--three{% endif %}">{% firstof card.heading card.page.title %}</h3>
                     {% if card.subheading %}

--- a/tbx/services/blocks.py
+++ b/tbx/services/blocks.py
@@ -6,7 +6,6 @@ from tbx.core.blocks import (
     BlogChooserBlock,
     EventBlock,
     FeaturedCaseStudyBlock,
-    FeaturedServicesBlock,
     FourPhotoCollageBlock,
     IconKeyPointsBlock,
     ImageWithAltTextBlock,

--- a/tbx/services/blocks.py
+++ b/tbx/services/blocks.py
@@ -6,6 +6,7 @@ from tbx.core.blocks import (
     BlogChooserBlock,
     EventBlock,
     FeaturedCaseStudyBlock,
+    FeaturedServicesBlock,
     FourPhotoCollageBlock,
     IconKeyPointsBlock,
     ImageWithAltTextBlock,
@@ -13,6 +14,7 @@ from tbx.core.blocks import (
     PartnersBlock,
     PhotoCollageBlock,
     PromoBlock,
+    ServiceAreaFeaturedServicesBlock,
     ShowcaseBlock,
     StoryBlock,
     StructBlockValidationError,
@@ -94,6 +96,7 @@ class OptionalLinkPromoBlock(PromoBlock):
 
 
 class ServiceAreaStoryBlock(StoryBlock):
+    featured_services = ServiceAreaFeaturedServicesBlock()
     blog_chooser = BlogChooserBlock()
     four_photo_collage = FourPhotoCollageBlock()
     key_points = IconKeyPointsBlock(label="Key points with icons")

--- a/tbx/static_src/sass/components/_featured-services.scss
+++ b/tbx/static_src/sass/components/_featured-services.scss
@@ -5,7 +5,7 @@
         margin-bottom: $spacer-medium;
     }
 
-        &__cards {
+    &__cards {
         display: flex;
         gap: $spacer-mini-plus;
         flex-wrap: wrap;

--- a/tbx/static_src/sass/components/_featured-services.scss
+++ b/tbx/static_src/sass/components/_featured-services.scss
@@ -5,17 +5,22 @@
         margin-bottom: $spacer-medium;
     }
 
-    &__cards {
-        display: grid;
+        &__cards {
+        display: flex;
         gap: $spacer-mini-plus;
-        grid-template-columns: repeat(1, 1fr);
+        flex-wrap: wrap;
 
         @include media-query(medium) {
-            grid-template-columns: repeat(2, 1fr);
+            > * {
+                flex: 1 1 40%;
+            }
         }
 
         @include media-query(x-large) {
-            grid-template-columns: repeat(auto-fit, minmax(0, 1fr));
+            > * {
+                flex: 1 1 20%;
+                min-width: 20%;
+            }
         }
     }
 


### PR DESCRIPTION
Monday Ticket - [Link to ticket](https://torchbox.monday.com/boards/1143413211/pulses/1960281240)
Jira Ticket - [Link to Ticket](https://torchbox.atlassian.net/browse/TMI-48)

### Description of Changes Made

When merged, this MR adds new ServiceAreaFeaturedServicesBlock which extends the current FeaturedServicesBlock to allow images to be optional and increase the min and mix number of cards to 6 and 8, respectively.

The block's styling has been changed from CSS Grid to Flex, allowing easy card wrapping over multiple lines.

### How to Test

1. Build the project locally as per the README and pull the sites staging data
2. Navigate to an existing [Service Area Page](http://127.0.0.1:8000/admin/pages/2560/edit/)
3. Add a new Featured Services block in the page body and populate it with a featured service card *making sure to include an image*. 
4. The card can be duplicated to meet the minimum number requirement and save effort.
5. Preview the page to ensure you can see the featured services.
6. Test unchecking the *Should display images* checkbox hides card images.
7. Ensure the *Should display images* checkbox is checked, and remove the image from one of the cards to test that it is an optional field.
8. Verify that having one card without an image hides the image for all cards.
9. Publish the page and view the local live version to ensure the page displays correctly at different viewport sizes.

### Screenshots

<details>
  <summary>6 cards - No images</summary>

![6 cards - no images - dark](https://github.com/user-attachments/assets/44343af6-e433-4328-93a9-36ef16a7d20f)

![6 cards - no images - light](https://github.com/user-attachments/assets/5ff13fbd-d847-42e0-a55c-8802f41f55c7)

</details>

<details>
  <summary>6 cards - With images</summary>

![6 cards - images - dark](https://github.com/user-attachments/assets/a97c0928-8ec6-44cc-9c1e-72402049e63a)

![6 cards - images - light](https://github.com/user-attachments/assets/a0750ce6-d242-4db6-a33d-22ab61414c91)

</details>

<details>
  <summary>7 cards - With images</summary>

![7 cards - dark](https://github.com/user-attachments/assets/35efef95-ca4e-4e3d-a322-ce1e99ed10a7)

</details>

<details>
  <summary>8 cards - With images</summary>

![8 cards - dark](https://github.com/user-attachments/assets/258dacb0-0445-43a7-92c8-cd7601fac6b4)</details>

### MR Checklist

- [ ] Add a description of your pull request and instructions for the reviewer to verify your work.
- [ ] If your pull request is for a specific ticket, link to it in the description.
- [ ] Stay on point and keep it small so the merge request can be easily reviewed.
- [ ] Tests and linting passes.

#### Unit tests

- [ ] Added
- [ ] Not required

#### Documentation

- [ ] Updated build docs
- [ ] Updated editor guidelines (See https://intranet.torchbox.com/torchbox-com-project-docs for the private link, for Torchbox employees only)
- [ ] Updated field spec (See https://intranet.torchbox.com/torchbox-com-project-docs for the private link, for Torchbox employees only)
- [ ] Not required

#### Browser testing

- [ ] I have tested in the following browsers and environments (edit the list as required)
  - Latest version of Chrome on mac
  - Latest version of Firefox on mac
  - Latest version of Safari on mac
  - Safari on last two versions of iOS
  - Chrome on last two versions of Android
- [ ] Not required

#### Data protection

- [X] Not relevant
- [ ] This adds new sources of PII and documents it and modifies Birdbath processors accordingly

#### Light and dark mode

- [X] I have tested the changes in both light and dark mode
- [ ] The change is not relevant to dark and light mode

#### Accessibility

- [ ] Automated WCAG 2.1 tests pass
- [ ] HTML validation passes
- [ ] Manual WCAG 2.1 tests completed
- [ ] I have tested in a screen reader
- [ ] I have tested in high-contrast mode
- [ ] Any animations removed for prefers-reduced-motion
- [ ] Not required

#### Sustainability

- [ ] Images are optimised and lazy-loading used where appropriate
- [ ] SVGs have been optimised
- [ ] Performance and transfer of data considered
- [ ] If JavaScript is needed alternatives have been considered
- [X] Not required

#### Pattern library

- [ ] The pattern library component for this template displays correctly, and does not break parent templates
- [ ] The styleguide is updated if relevant
- [X] Changes are not relevant the pattern library
