### PR TITLE
Allow 404 pages to be cached

### DIFF
--- a/cloudflare/workers.js
+++ b/cloudflare/workers.js
@@ -93,9 +93,10 @@ const REPLACE_STRIPPED_QUERYSTRING_ON_REDIRECT_LOCATION = false;
 // Disabled by default, but highly recommended
 const STRIP_VALUELESS_QUERYSTRING_KEYS = false;
 
-// Only these status codes should be considered cacheable
+// Only these status codes should be considered cacheable.
 // (from https://www.w3.org/Protocols/rfc2616/rfc2616-sec13.html#sec13.4)
-const CACHABLE_HTTP_STATUS_CODES = [200, 203, 206, 300, 301, 410];
+// 404 is added to reduce server load on spammed requests.
+const CACHABLE_HTTP_STATUS_CODES = [200, 203, 206, 300, 301, 404, 410];
 
 addEventListener('fetch', (event) => {
     event.respondWith(main(event));

--- a/tbx/core/tests/test_views.py
+++ b/tbx/core/tests/test_views.py
@@ -107,3 +107,21 @@ class TestModeSwitcherView(TestCase):
         # check theme is set on new site
         resp = self.client.get(f"http://{new_site.hostname}/")
         self.assertEqual(resp.context["MODE"], mode)
+
+
+class PageNotFoundTestCase(TestCase):
+    def test_page_not_found(self) -> None:
+        response = self.client.get("/does-not-exist/")
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(
+            response.headers["Cache-Control"],
+            "s-maxage=600, stale-while-revalidate=60, public",
+        )
+
+    def test_test_404(self) -> None:
+        response = self.client.get("/test404/")
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(
+            response.headers["Cache-Control"],
+            "s-maxage=600, stale-while-revalidate=60, public",
+        )

--- a/tbx/core/utils/views.py
+++ b/tbx/core/utils/views.py
@@ -1,9 +1,16 @@
 from django.views import defaults
+from django.views.decorators.cache import cache_control, never_cache
+
+from tbx.core.utils.cache import get_default_cache_control_kwargs
 
 
-def page_not_found(request, exception, template_name="patterns/pages/errors/404.html"):
+@cache_control(**(get_default_cache_control_kwargs() | {"s_maxage": 600}))
+def page_not_found(
+    request, exception=None, template_name="patterns/pages/errors/404.html"
+):
     return defaults.page_not_found(request, exception, template_name)
 
 
+@never_cache
 def server_error(request, template_name="patterns/pages/errors/500.html"):
     return defaults.server_error(request, template_name)

--- a/tbx/settings/base.py
+++ b/tbx/settings/base.py
@@ -22,6 +22,7 @@ BASE_DIR = os.path.dirname(PROJECT_DIR)
 
 # Basic settings
 DEBUG = False
+TEST = False
 
 APP_NAME = env.get("APP_NAME", "torchbox")
 
@@ -549,13 +550,13 @@ elif "FRONTEND_CACHE_CLOUDFLARE_TOKEN" in env:
 # Set s-max-age header that is used by reverse proxy/front end cache. See
 # urls.py
 with contextlib.suppress(ValueError):
-    CACHE_CONTROL_S_MAXAGE = int(env.get("CACHE_CONTROL_S_MAXAGE", 600))
+    CACHE_CONTROL_S_MAXAGE = int(env.get("CACHE_CONTROL_S_MAXAGE", 14400))
 
 
-# Give front-end cache 30 second to revalidate the cache to avoid hitting the
+# Give front-end cache 60 second to revalidate the cache to avoid hitting the
 # backend. See urls.py
 CACHE_CONTROL_STALE_WHILE_REVALIDATE = int(
-    env.get("CACHE_CONTROL_STALE_WHILE_REVALIDATE", 30)
+    env.get("CACHE_CONTROL_STALE_WHILE_REVALIDATE", 60)
 )
 
 # Embeds

--- a/tbx/settings/test.py
+++ b/tbx/settings/test.py
@@ -1,6 +1,8 @@
 from .base import *  # noqa: F403
 
 
+TEST = True
+
 # #############
 # General
 

--- a/tbx/urls.py
+++ b/tbx/urls.py
@@ -17,6 +17,7 @@ from tbx.core.utils.cache import (
     get_default_cache_control_decorator,
     get_default_cache_control_method_decorator,
 )
+from tbx.core.utils.views import page_not_found, server_error
 from tbx.core.views import robots, switch_mode
 
 
@@ -32,26 +33,19 @@ urlpatterns = [
 ]
 
 
-if settings.DEBUG:
+if settings.DEBUG or settings.TEST:
     from django.conf.urls.static import static
     from django.contrib.staticfiles.urls import staticfiles_urlpatterns
-    from django.views.generic import TemplateView
 
     # Serve static and media files from development server
     urlpatterns += staticfiles_urlpatterns()
     urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 
     # Add views for testing 404 and 500 templates
-    urlpatterns += [
+    private_urlpatterns += [
         # Add views for testing 404 and 500 templates
-        path(
-            "test404/",
-            TemplateView.as_view(template_name="patterns/pages/errors/404.html"),
-        ),
-        path(
-            "test500/",
-            TemplateView.as_view(template_name="patterns/pages/errors/500.html"),
-        ),
+        path("test404/", page_not_found),
+        path("test500/", server_error),
     ]
 
     # Django Debug Toolbar
@@ -104,5 +98,5 @@ urlpatterns = (
 )
 
 # Error handlers
-handler404 = "tbx.core.utils.views.page_not_found"
-handler500 = "tbx.core.utils.views.server_error"
+handler404 = page_not_found
+handler500 = server_error


### PR DESCRIPTION
### Description of Changes Made

If a page returns a 404, chances are it'll still be a 404 in 10 minutes time, or even longer. Therefore, it's probably something which can be cached to reduce system load.

According to [RFC2616](https://www.w3.org/Protocols/rfc2616/rfc2616-sec13.html#sec13.4), 404s should not be cached. However, for our use case, I think it's worth it. The TTL is intentionally shorter than it probably could be, but this could be increased in future.

In Wagtail, a request will always do a database query. Potentially multiple depending on how much of the path _does_ exist. Therefore, missing pages can result in higher than expected usage, and won't be cached by an edge cache. Worse still, because the 404 pages usually shown are fancy HTML versions, they may do queries in themselves (for eg navigation), making 404s more expensive still.

By caching the 404, we reduce the impact on users viewing it in future, especially useful if a site is being crawled, as many frontend caches will normalise URLs before caching ([ours sure does](https://github.com/torchbox/cloudflare-recipes/blob/master/common-caching.js#L29)).

If a 404 has been cached, and a page is created in its place, Wagtail's existing frontend caching will purge the 404s cache during publishing.

Related reading:

- https://kinsta.com/blog/wordpress-cache/#caching-404-pages
- https://docs.litespeedtech.com/lscache/lscwp/cache/#default-http-status-code-page-ttl
- https://www.drupal.org/project/reuse_cached_404

### How to Test

404 pages now have a `Cache-Control` header which allows them to be cached.

### MR Checklist

- [x] Add a description of your pull request and instructions for the reviewer to verify your work.
- [ ] If your pull request is for a specific ticket, link to it in the description.
- [x] Stay on point and keep it small so the merge request can be easily reviewed.
- [x] Tests and linting passes.

#### Unit tests

- [x] Added
- [ ] Not required

#### Documentation

- [ ] Updated build docs
- [ ] Updated editor guidelines (See https://intranet.torchbox.com/torchbox-com-project-docs for the private link, for Torchbox employees only)
- [ ] Updated field spec (See https://intranet.torchbox.com/torchbox-com-project-docs for the private link, for Torchbox employees only)
- [x] Not required

#### Browser testing

- [ ] I have tested in the following browsers and environments (edit the list as required)
  - Latest version of Chrome on mac
  - Latest version of Firefox on mac
  - Latest version of Safari on mac
  - Safari on last two versions of iOS
  - Chrome on last two versions of Android
- [x] Not required

#### Data protection

- [x] Not relevant
- [ ] This adds new sources of PII and documents it and modifies Birdbath processors accordingly

#### Light and dark mode

- [ ] I have tested the changes in both light and dark mode
- [x] The change is not relevant to dark and light mode

#### Accessibility

- [ ] Automated WCAG 2.1 tests pass
- [ ] HTML validation passes
- [ ] Manual WCAG 2.1 tests completed
- [ ] I have tested in a screen reader
- [ ] I have tested in high-contrast mode
- [ ] Any animations removed for prefers-reduced-motion
- [x] Not required

#### Sustainability

- [ ] Images are optimised and lazy-loading used where appropriate
- [ ] SVGs have been optimised
- [x] Performance and transfer of data considered
- [ ] If JavaScript is needed alternatives have been considered
- [ ] Not required

#### Pattern library

- [ ] The pattern library component for this template displays correctly, and does not break parent templates
- [ ] The styleguide is updated if relevant
- [x] Changes are not relevant the pattern library
