### PR TITLE
Serve simple error pages if HTML isn't required

### DIFF
--- a/tbx/core/tests/test_views.py
+++ b/tbx/core/tests/test_views.py
@@ -107,3 +107,25 @@ class TestModeSwitcherView(TestCase):
         # check theme is set on new site
         resp = self.client.get(f"http://{new_site.hostname}/")
         self.assertEqual(resp.context["MODE"], mode)
+
+
+class PageNotFoundTestCase(TestCase):
+    url = "/does-not-exist/"
+
+    def test_accept_html(self) -> None:
+        response = self.client.get(self.url, headers={"Accept": "text/html"})
+        self.assertEqual(response.status_code, 404)
+        self.assertIn("text/html", response.headers["content-type"])
+        self.assertEqual(response.headers["Vary"], "Accept, Cookie")
+
+    def test_accept_text(self) -> None:
+        response = self.client.get(self.url, headers={"Accept": "text/plain"})
+        self.assertEqual(response.status_code, 404)
+        self.assertIn("text/plain", response.headers["content-type"])
+        self.assertEqual(response.headers["Vary"], "Accept")
+
+    def test_simple_when_doesnt_accept_html(self) -> None:
+        response = self.client.get(self.url, headers={"Accept": "text/css"})
+        self.assertEqual(response.status_code, 404)
+        self.assertIn("text/plain", response.headers["content-type"])
+        self.assertEqual(response.headers["Vary"], "Accept")

--- a/tbx/core/utils/views.py
+++ b/tbx/core/utils/views.py
@@ -1,9 +1,34 @@
+from django.http import HttpResponseNotFound, HttpResponseServerError
 from django.views import defaults
+from django.views.decorators.vary import vary_on_headers
 
 
+def show_html_error_page(request):
+    """
+    - If HTML is the most preferred type, show HTML.
+    - If plain text is most preferred, don't show HTML
+    - If neither are accepted, don't show HTML
+    """
+    return request.get_preferred_type(["text/html", "text/plain"]) == "text/html"
+
+
+@vary_on_headers("Accept")
 def page_not_found(request, exception, template_name="patterns/pages/errors/404.html"):
-    return defaults.page_not_found(request, exception, template_name)
+    if show_html_error_page(request):
+        return defaults.page_not_found(request, exception, template_name)
+
+    # Serve a simpler, cheaper 404 page if possible
+    return HttpResponseNotFound(
+        "Page not found", content_type="text/plain; charset=utf-8"
+    )
 
 
+@vary_on_headers("Accept")
 def server_error(request, template_name="patterns/pages/errors/500.html"):
-    return defaults.server_error(request, template_name)
+    if show_html_error_page(request):
+        return defaults.server_error(request, template_name)
+
+    # Serve a simpler, cheaper 500 page if possible
+    return HttpResponseServerError(
+        "Server error", content_type="text/plain; charset=utf-8"
+    )

--- a/tbx/urls.py
+++ b/tbx/urls.py
@@ -17,6 +17,7 @@ from tbx.core.utils.cache import (
     get_default_cache_control_decorator,
     get_default_cache_control_method_decorator,
 )
+from tbx.core.utils.views import page_not_found, server_error
 from tbx.core.views import robots, switch_mode
 
 
@@ -35,7 +36,6 @@ urlpatterns = [
 if settings.DEBUG:
     from django.conf.urls.static import static
     from django.contrib.staticfiles.urls import staticfiles_urlpatterns
-    from django.views.generic import TemplateView
 
     # Serve static and media files from development server
     urlpatterns += staticfiles_urlpatterns()
@@ -44,14 +44,8 @@ if settings.DEBUG:
     # Add views for testing 404 and 500 templates
     urlpatterns += [
         # Add views for testing 404 and 500 templates
-        path(
-            "test404/",
-            TemplateView.as_view(template_name="patterns/pages/errors/404.html"),
-        ),
-        path(
-            "test500/",
-            TemplateView.as_view(template_name="patterns/pages/errors/500.html"),
-        ),
+        path("test404/", page_not_found),
+        path("test500/", server_error),
     ]
 
     # Django Debug Toolbar
@@ -104,5 +98,5 @@ urlpatterns = (
 )
 
 # Error handlers
-handler404 = "tbx.core.utils.views.page_not_found"
-handler500 = "tbx.core.utils.views.server_error"
+handler404 = page_not_found
+handler500 = server_error


### PR DESCRIPTION
### Description of Changes Made

Our 404 page is a fancy HTML page, comprised of multiple templates, and requiring a number of DB queries to create (not many queries, granted). If a person in a browser loads a page, we want to show them this "fancy" 404 page for a better user experience. However, if the request shouldn't return HTML (eg it's a missing static file) or user never asked for HTML, we shouldn't spend the time creating a fancy 404 page if it's never going to be viewed.

Instead, when possible, we show a simplified HTML page, which just contains text. This requires much fewer resources to generate, and is quicker to serve.

### How to Test

If you go to a missing page with `curl`, you should just get some text, rather than a full HTML page.

### MR Checklist

- [x] Add a description of your pull request and instructions for the reviewer to verify your work.
- [x] If your pull request is for a specific ticket, link to it in the description.
- [ ] Stay on point and keep it small so the merge request can be easily reviewed.
- [ ] Tests and linting passes.

#### Unit tests

- [x] Added
- [ ] Not required

#### Documentation

- [ ] Updated build docs
- [ ] Updated editor guidelines (See https://intranet.torchbox.com/torchbox-com-project-docs for the private link, for Torchbox employees only)
- [ ] Updated field spec (See https://intranet.torchbox.com/torchbox-com-project-docs for the private link, for Torchbox employees only)
- [x] Not required

#### Browser testing

- [ ] I have tested in the following browsers and environments (edit the list as required)
  - Latest version of Chrome on mac
  - Latest version of Firefox on mac
  - Latest version of Safari on mac
  - Safari on last two versions of iOS
  - Chrome on last two versions of Android
- [x] Not required

#### Data protection

- [x] Not relevant
- [ ] This adds new sources of PII and documents it and modifies Birdbath processors accordingly

#### Light and dark mode

- [ ] I have tested the changes in both light and dark mode
- [x] The change is not relevant to dark and light mode

#### Accessibility

- [ ] Automated WCAG 2.1 tests pass
- [ ] HTML validation passes
- [ ] Manual WCAG 2.1 tests completed
- [ ] I have tested in a screen reader
- [ ] I have tested in high-contrast mode
- [ ] Any animations removed for prefers-reduced-motion
- [x] Not required

#### Sustainability

- [ ] Images are optimised and lazy-loading used where appropriate
- [ ] SVGs have been optimised
- [x] Performance and transfer of data considered
- [ ] If JavaScript is needed alternatives have been considered
- [ ] Not required

#### Pattern library

- [ ] The pattern library component for this template displays correctly, and does not break parent templates
- [ ] The styleguide is updated if relevant
- [x] Changes are not relevant the pattern library
