### PR TITLE
Revert django-csp to v3.8

### DIFF
--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -82,6 +82,14 @@ As much as possible, we want to use the official releases available on PyPI for 
 - wagtailmedia
 - wagtail-purge
 
+## django-csp
+
+**Last tested for wagtail 7.0.1 upgrade** The current version of django-csp is ~3.8
+
+v4.0 has breaking changes, so we are using the latest version of v3.x.
+
+See the django-csp upgrade notes <https://github.com/mozilla/django-csp/blob/main/CHANGES.md#40>
+
 ## Custom wagtail admin templates
 
 **Last checked** Wagtail 7.0 upgrade

--- a/poetry.lock
+++ b/poetry.lock
@@ -588,24 +588,21 @@ dev = ["django (>=4.2,<5.0)", "pre-commit (>=3.8.0)", "pytest (>=8.3,<9.0)", "py
 
 [[package]]
 name = "django-csp"
-version = "4.0"
+version = "3.8"
 description = "Django Content Security Policy support."
 optional = false
 python-versions = "*"
 files = [
-    {file = "django_csp-4.0-py3-none-any.whl", hash = "sha256:d5a0a05463a6b75a4f1fc1828c58c89af8db9364d09fc6e12f122b4d7f3d00dc"},
-    {file = "django_csp-4.0.tar.gz", hash = "sha256:b27010bb702eb20a3dad329178df2b61a2b82d338b70fbdc13c3a3bd28712833"},
+    {file = "django_csp-3.8-py3-none-any.whl", hash = "sha256:19b2978b03fcd73517d7d67acbc04fbbcaec0facc3e83baa502965892d1e0719"},
+    {file = "django_csp-3.8.tar.gz", hash = "sha256:ef0f1a9f7d8da68ae6e169c02e9ac661c0ecf04db70e0d1d85640512a68471c0"},
 ]
 
 [package.dependencies]
-django = ">=4.2"
-packaging = "*"
+Django = ">=3.2"
 
 [package.extras]
-dev = ["django-stubs[compatible-mypy]", "jinja2 (>=2.9.6)", "mypy", "pre-commit", "pytest", "pytest-cov", "pytest-django", "pytest-ruff", "sphinx", "sphinx-rtd-theme", "tox", "tox-gh-actions", "types-setuptools"]
 jinja2 = ["jinja2 (>=2.9.6)"]
 tests = ["jinja2 (>=2.9.6)", "pytest", "pytest-cov", "pytest-django", "pytest-ruff"]
-typing = ["django-stubs[compatible-mypy]", "jinja2 (>=2.9.6)", "mypy", "pytest", "pytest-django", "types-setuptools"]
 
 [[package]]
 name = "django-debug-toolbar"
@@ -2603,4 +2600,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.13"
-content-hash = "a68b134b895fc2d50c10b6582f71d3e67589d7e517a5c5f50bf0e438f4ff314c"
+content-hash = "372665b860476bc249e2f675b35e9191ac044701aab507535ddd9f2427f23a6b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ Wand = "^0.6.10"
 # Django packages
 django-basic-auth-ip-whitelist = "^0.8"
 django-birdbath = "^2.0.0"
-django-csp = "^4.0"
+django-csp = "~3.8" # v4.0 has breaking changes see upgrading notes
 django-pattern-library = "^1.3.0"
 django-permissions-policy = "^4.26.0"
 django-phonenumber-field = "^8.1.0"


### PR DESCRIPTION
Revert django-csp package back to version ~3.8 because v4.0 has breaking changes.

CSP isn't configured in Heroku production settings so isn't actually used.

[Link to Ticket]()

### Description of Changes Made

### How to Test

### Screenshots

<details>
  <summary>Expand to see more</summary>

</details>

### MR Checklist

- [ ] Add a description of your pull request and instructions for the reviewer to verify your work.
- [ ] If your pull request is for a specific ticket, link to it in the description.
- [ ] Stay on point and keep it small so the merge request can be easily reviewed.
- [ ] Tests and linting passes.

#### Unit tests

- [ ] Added
- [ ] Not required

#### Documentation

- [ ] Updated build docs
- [ ] Updated editor guidelines (See https://intranet.torchbox.com/torchbox-com-project-docs for the private link, for Torchbox employees only)
- [ ] Updated field spec (See https://intranet.torchbox.com/torchbox-com-project-docs for the private link, for Torchbox employees only)
- [ ] Not required

#### Browser testing

- [ ] I have tested in the following browsers and environments (edit the list as required)
  - Latest version of Chrome on mac
  - Latest version of Firefox on mac
  - Latest version of Safari on mac
  - Safari on last two versions of iOS
  - Chrome on last two versions of Android
- [ ] Not required

#### Data protection

- [ ] Not relevant
- [ ] This adds new sources of PII and documents it and modifies Birdbath processors accordingly

#### Light and dark mode

- [ ] I have tested the changes in both light and dark mode
- [ ] The change is not relevant to dark and light mode

#### Accessibility

- [ ] Automated WCAG 2.1 tests pass
- [ ] HTML validation passes
- [ ] Manual WCAG 2.1 tests completed
- [ ] I have tested in a screen reader
- [ ] I have tested in high-contrast mode
- [ ] Any animations removed for prefers-reduced-motion
- [ ] Not required

#### Sustainability

- [ ] Images are optimised and lazy-loading used where appropriate
- [ ] SVGs have been optimised
- [ ] Performance and transfer of data considered
- [ ] If JavaScript is needed alternatives have been considered
- [ ] Not required

#### Pattern library

- [ ] The pattern library component for this template displays correctly, and does not break parent templates
- [ ] The styleguide is updated if relevant
- [ ] Changes are not relevant the pattern library
