### PR TITLE
TWE-669: Make key point heading optional

### DIFF
--- a/tbx/core/blocks.py
+++ b/tbx/core/blocks.py
@@ -421,7 +421,7 @@ class IconKeyPointBlock(blocks.StructBlock):
         max_length=32,
     )
     icon_label = blocks.CharBlock()
-    heading = blocks.CharBlock()
+    heading = blocks.CharBlock(required=False)
     description = blocks.RichTextBlock(features=settings.NO_HEADING_RICH_TEXT_FEATURES)
 
     class Meta:

--- a/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/icon_keypoints_block.html
+++ b/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/icon_keypoints_block.html
@@ -16,10 +16,14 @@
                     <p class="keypoints__label">{{ key_point.icon_label }}</p>
                     {% include "patterns/atoms/icons/icon.html" with name=key_point.icon classname="keypoints__icon" %}
                 </div>
-                    {# header title is optional, so heading here may be h2 #}
-                <{% if value.title %}h3{% else %}h2{% endif %} class="keypoints__heading">
-                {{ key_point.heading }}
-                {% if value.title %}</h3>{% else %}</h2>{% endif %}
+                {% if key_point.heading %}
+                        {# header title is optional, so heading here may be h2 #}
+                    {% with value.title|yesno:"h3,h2" as HTAG %}
+                        <{{ HTAG }} class="keypoints__heading">
+                        {{ key_point.heading }}
+                        </{{ HTAG }}>
+                    {% endwith %}
+                {% endif %}
                 <div class="keypoints__description">{{ key_point.description|richtext }}</div>
             </li>
         {% endfor %}


### PR DESCRIPTION
[Link to Ticket](https://torchbox.atlassian.net/browse/TWE-669)

### Description of Changes Made

This PR makes the "heading" field of the `IconKeyPointBlock` block optional

### How to Test

### Screenshots

<details>
  <summary>Two blocks without heading</summary>
<img width="1495" height="757" alt="Screenshot 2025-09-05 at 08-26-31 Service area 1" src="https://github.com/user-attachments/assets/479d179e-e14e-4af4-accb-6d4ed1dad631" />

</details>

### MR Checklist

- [ ] Add a description of your pull request and instructions for the reviewer to verify your work.
- [ ] If your pull request is for a specific ticket, link to it in the description.
- [ ] Stay on point and keep it small so the merge request can be easily reviewed.
- [ ] Tests and linting passes.

#### Unit tests

- [ ] Added
- [ ] Not required

#### Documentation

- [ ] Updated build docs
- [ ] Updated editor guidelines (See https://intranet.torchbox.com/torchbox-com-project-docs for the private link, for Torchbox employees only)
- [ ] Updated field spec (See https://intranet.torchbox.com/torchbox-com-project-docs for the private link, for Torchbox employees only)
- [ ] Not required

#### Browser testing

- [ ] I have tested in the following browsers and environments (edit the list as required)
  - Latest version of Chrome on mac
  - Latest version of Firefox on mac
  - Latest version of Safari on mac
  - Safari on last two versions of iOS
  - Chrome on last two versions of Android
- [ ] Not required

#### Data protection

- [ ] Not relevant
- [ ] This adds new sources of PII and documents it and modifies Birdbath processors accordingly

#### Light and dark mode

- [ ] I have tested the changes in both light and dark mode
- [ ] The change is not relevant to dark and light mode

#### Accessibility

- [ ] Automated WCAG 2.1 tests pass
- [ ] HTML validation passes
- [ ] Manual WCAG 2.1 tests completed
- [ ] I have tested in a screen reader
- [ ] I have tested in high-contrast mode
- [ ] Any animations removed for prefers-reduced-motion
- [ ] Not required

#### Sustainability

- [ ] Images are optimised and lazy-loading used where appropriate
- [ ] SVGs have been optimised
- [ ] Performance and transfer of data considered
- [ ] If JavaScript is needed alternatives have been considered
- [ ] Not required

#### Pattern library

- [ ] The pattern library component for this template displays correctly, and does not break parent templates
- [ ] The styleguide is updated if relevant
- [ ] Changes are not relevant the pattern library
