### PR TITLE
Fix deleted page value errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,13 @@ All notable changes to this project will be documented in this file. This projec
 
 Add your changes to the Unreleased section and move them to the appropriate section when they are merged.
 
-## Unreleased
+## 2026-05-13
+
+- Fix 500 error on pages where a referenced page in a chooser block has been deleted
+
+## 2026-03-26
 
 - [TWE-682](https://torchbox.atlassian.net/browse/TWE-682) - Upgrade Wagtail to 7.3
-- Fix 500 error on pages where a referenced page in a chooser block has been deleted
 
 ## 2026-03-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Add your changes to the Unreleased section and move them to the appropriate sect
 ## Unreleased
 
 - [TWE-682](https://torchbox.atlassian.net/browse/TWE-682) - Upgrade Wagtail to 7.3
+- Fix 500 error on pages where a referenced page in a chooser block has been deleted
 
 ## 2026-03-05
 

--- a/tbx/core/blocks.py
+++ b/tbx/core/blocks.py
@@ -748,6 +748,25 @@ class FeaturedCaseStudyBlock(blocks.StructBlock):
         return struct_value
 
 
+def _resolve_chooser_pages(raw_pages, prefetch_related=None):
+    """Resolve a raw block page list to live, public, specific pages in order.
+
+    Silently drops None values (deleted pages from PageChooserBlock.to_python).
+    """
+    page_ids = [p.pk for p in raw_pages if p is not None]
+    qs = (
+        Page.objects.filter(pk__in=page_ids)
+        .live()
+        .public()
+        .defer_streamfields()
+        .specific()
+    )
+    if prefetch_related:
+        qs = qs.prefetch_related(prefetch_related)
+    pages = qs.in_bulk()
+    return [pages[_id] for _id in page_ids if _id in pages]
+
+
 class BlogChooserBlock(blocks.StructBlock):
     featured_blog_heading = blocks.CharBlock(max_length=255)
     intro = blocks.RichTextBlock(
@@ -764,6 +783,7 @@ class BlogChooserBlock(blocks.StructBlock):
     def get_context(self, value, parent_context=None):
         context = super().get_context(value, parent_context=parent_context)
         context["is_standard_page"] = False
+        context["blog_pages"] = _resolve_chooser_pages(value["blog_pages"])
         return context
 
     class Meta:
@@ -805,20 +825,9 @@ class WorkChooserBlock(blocks.StructBlock):
             ),
         )
 
-        work_page_ids = [page.pk for page in value["work_pages"]]
-        work_pages = (
-            Page.objects.filter(pk__in=work_page_ids)
-            .live()
-            .public()
-            .defer_streamfields()
-            .prefetch_related(prefetch_listing_images)
-            .specific()
-            .in_bulk()
+        context["work_pages"] = _resolve_chooser_pages(
+            value["work_pages"], prefetch_related=prefetch_listing_images
         )
-        # Keeps the ordering the same as in values.
-        context["work_pages"] = [
-            work_pages[_id] for _id in work_page_ids if _id in work_pages
-        ]
         context["is_standard_page"] = False
         return context
 

--- a/tbx/core/tests/test_blocks.py
+++ b/tbx/core/tests/test_blocks.py
@@ -1,7 +1,33 @@
 from django.test import TestCase
 
-from tbx.core.blocks import WorkChooserBlock
+from tbx.blog.factories import BlogPageFactory
+from tbx.core.blocks import BlogChooserBlock, WorkChooserBlock, _resolve_chooser_pages
 from tbx.work.factories import WorkPageFactory
+
+
+class ResolveChooserPagesTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.pages = WorkPageFactory.create_batch(3)
+
+    def test_returns_live_public_pages_in_order(self):
+        result = _resolve_chooser_pages(self.pages)
+        self.assertListEqual(result, self.pages)
+
+    def test_preserves_custom_order(self):
+        reversed_pages = list(reversed(self.pages))
+        result = _resolve_chooser_pages(reversed_pages)
+        self.assertListEqual(result, reversed_pages)
+
+    def test_drops_none_deleted_pages(self):
+        pages_with_deleted = [None, self.pages[0], None, self.pages[1]]
+        result = _resolve_chooser_pages(pages_with_deleted)
+        self.assertListEqual(result, [self.pages[0], self.pages[1]])
+
+    def test_drops_unpublished_pages(self):
+        self.pages[0].unpublish()
+        result = _resolve_chooser_pages(self.pages)
+        self.assertListEqual(result, [self.pages[1], self.pages[2]])
 
 
 class WorkChooserBlockTest(TestCase):
@@ -35,3 +61,57 @@ class WorkChooserBlockTest(TestCase):
             {"featured_work_heading": "Featured Work", "work_pages": self.pages}
         )
         self.assertListEqual(context["work_pages"], [self.pages[1], self.pages[2]])
+
+    def test_block_context_with_deleted_pages(self):
+        block = WorkChooserBlock()
+        pages_with_deleted = [None, self.pages[0], self.pages[1]]
+
+        context = block.get_context(
+            {"featured_work_heading": "Featured Work", "work_pages": pages_with_deleted}
+        )
+        self.assertListEqual(context["work_pages"], [self.pages[0], self.pages[1]])
+
+
+class BlogChooserBlockTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.pages = BlogPageFactory.create_batch(3)
+
+    def test_block_context(self):
+        block = BlogChooserBlock()
+
+        context = block.get_context(
+            {"featured_blog_heading": "Featured Blog", "blog_pages": self.pages}
+        )
+        self.assertListEqual(context["blog_pages"], self.pages)
+
+        context = block.get_context(
+            {
+                "featured_blog_heading": "Featured Blog",
+                "blog_pages": [self.pages[2], self.pages[1], self.pages[0]],
+            }
+        )
+        self.assertListEqual(
+            context["blog_pages"], [self.pages[2], self.pages[1], self.pages[0]]
+        )
+
+    def test_block_context_with_unpublished_pages(self):
+        block = BlogChooserBlock()
+        self.pages[0].unpublish()
+
+        context = block.get_context(
+            {"featured_blog_heading": "Featured Blog", "blog_pages": self.pages}
+        )
+        self.assertListEqual(context["blog_pages"], [self.pages[1], self.pages[2]])
+
+    def test_block_context_with_deleted_pages(self):
+        block = BlogChooserBlock()
+        pages_with_deleted = [None, self.pages[0], self.pages[1]]
+
+        context = block.get_context(
+            {
+                "featured_blog_heading": "Featured Blog",
+                "blog_pages": pages_with_deleted,
+            }
+        )
+        self.assertListEqual(context["blog_pages"], [self.pages[0], self.pages[1]])

--- a/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/blog_chooser_block.html
+++ b/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/blog_chooser_block.html
@@ -19,7 +19,7 @@
 {# Blog posts #}
 <div class="grid__related-posts mb-spacerMedium lg:mb-spacerLarge">
     <ul class="streamfield__related-posts mb-spacerMedium lg:mb-spacerLarge">
-        {% for blog_page in value.blog_pages %}
+        {% for blog_page in blog_pages %}
             {% pageurl blog_page.blog_index as blog_index_url %}
             {% pageurl blog_page as blog_post_url %}
             {% include "patterns/molecules/listing/listing--avatar.html" with title=blog_page.title name=blog_page.first_author.name job_title=blog_page.first_author.role link=blog_post_url date=blog_page.date reading_time=blog_page.read_time tags=blog_page.tags hide_tags=True avatar=blog_page.first_author.image tag_link_base=blog_index_url %}

--- a/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/blog_chooser_block.yaml
+++ b/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/blog_chooser_block.yaml
@@ -10,40 +10,40 @@ context:
       - value:
           text: Secondary button
           url: '#'
-    blog_pages:
-      - title: Explore the potential of AI in content management
-        date: 20 Oct 2023
-        read_time: '5'
-        first_author:
-          name: Will Heinemann
-          role: New Business Director
-        tags:
-          - name: Digital products
-            slug: digital-products
-          - name: Wagtail
-            slug: wagtail
-      - title: Explore the potential of AI in content management
-        date: 20 Oct 2023
-        read_time: '5'
-        first_author:
-          name: Will Heinemann
-          role: New Business Director
-        tags:
-          - name: Digital products
-            slug: digital-products
-          - name: Wagtail
-            slug: wagtail
-      - title: Explore the potential of AI in content management
-        date: 20 Oct 2023
-        read_time: '5'
-        first_author:
-          name: Will Heinemann
-          role: New Business Director
-        tags:
-          - name: Digital products
-            slug: digital-products
-          - name: Wagtail
-            slug: wagtail
+  blog_pages:
+    - title: Explore the potential of AI in content management
+      date: 20 Oct 2023
+      read_time: '5'
+      first_author:
+        name: Will Heinemann
+        role: New Business Director
+      tags:
+        - name: Digital products
+          slug: digital-products
+        - name: Wagtail
+          slug: wagtail
+    - title: Explore the potential of AI in content management
+      date: 20 Oct 2023
+      read_time: '5'
+      first_author:
+        name: Will Heinemann
+        role: New Business Director
+      tags:
+        - name: Digital products
+          slug: digital-products
+        - name: Wagtail
+          slug: wagtail
+    - title: Explore the potential of AI in content management
+      date: 20 Oct 2023
+      read_time: '5'
+      first_author:
+        name: Will Heinemann
+        role: New Business Director
+      tags:
+        - name: Digital products
+          slug: digital-products
+        - name: Wagtail
+          slug: wagtail
 
 tags:
   pageurl:

--- a/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/division_signpost_block.html
+++ b/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/division_signpost_block.html
@@ -18,7 +18,7 @@
                 </div>
                 {% srcset_image card.image format-webp fill-{540x280,490x280} sizes="(max-width: 598px) 540px, (min-width: 599px) 490px" alt="" loading="lazy" %}
                 {# The title and icon need to be on the same line with no whitespace to prevent the arrow being orphaned on a new line #}
-                <a href="{% pageurl card.page %}"
+                <a href="{% if card.page %}{% pageurl card.page %}{% endif %}"
                    class="button-link button-link--{{ card.card_colour }}"
                    {% if card.accessible_link_text %}aria-label="{{ card.accessible_link_text }}"{% endif %}
                 >

--- a/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/featured_services_block.html
+++ b/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/featured_services_block.html
@@ -23,7 +23,7 @@
                     <div class="featured-services__description rich-text">{{ card.description|richtext }}</div>
                 </div>
                 {# The title and icon need to be on the same line with no whitespace to prevent the arrow being orphaned on a new line #}
-                <a href="{% pageurl card.page %}"
+                <a href="{% if card.page %}{% pageurl card.page %}{% endif %}"
                    class="button-link button-link--compact"
                    {% if card.accessible_link_text %}aria-label="{{ card.accessible_link_text }}"{% endif %}
                 >


### PR DESCRIPTION
### Issue

Visiting /charity/scale-impact-through-technology/development/ produced a 500 error:

```ValueError: pageurl tag expected a Page object, got ''```

This happened because of a referenced page being deleted from a `BlogChooserBlock`, causing Wagtail's `PageChooserBlock.to_python` to return `None` for the page ID. Unlike `WorkChooserBlock`, `BlogChooserBlock.get_context` passes the raw list of IDs straight to the template, leaving `None` in it.

The deletion of a page with pk 2915 on May 6 triggered the bug; until then it was latent in the codebase, and was not introduced by any recent code change.

### Fixes made

- e92ea57087538386b35c6ed9c1d87c1d307f5795 - root cause fix

As `WorkChooserBlock` already had handling for this scenario, this logic is abstracted out to  a `_resolve_chooser_pages` helper that fetches a raw `ListBlock` page list (live, public, specific page instances in order), dropping any `None` values from deleted pages. This helper's added to both `BlogChooserBlock` and `WorkChooserBlock`.

The _blog_chooser_block.html_ template is updated to iterate the processed `blog_pages` context variable, matching the existing _work_chooser_block.html_ pattern.

- 381e668ce8ecab88877c1e1a3549d833d77a7cb8 - other defensive guards:

Checks for similar issues found that `FeaturedServicesBlock` and `DivisionSignpostBlock` templates called `{% pageurl card.page %}` unconditionally on cards whose `page` field can become `None` through page deletion. Guards for `{% if card.page %}` added, matching the existing pattern in _showcase_block.html_.

- 15ef555657efa230983a5189f4f40171f1418301 - pattern library updates

### How to Test

1. Find any page with a `BlogChooserBlock` in its body
2. In the Wagtail admin, delete one of the pages it references
3. Visit the page: it should render cleanly with the deleted item simply omitted from the listing (or the card link rendered with an empty href for the card-based blocks)
4. Repeat for `FeaturedServicesBlock` and `DivisionSignpostBlock`

### MR Checklist

- [x] Add a description of your pull request and instructions for the reviewer to verify your work.
- [ ] ~~If your pull request is for a specific ticket, link to it in the description.~~
- [x] Stay on point and keep it small so the merge request can be easily reviewed.
- [x] Tests and linting passes.

#### Unit tests

- [x] Added
- [ ] Not required

#### Documentation

- [ ] Updated build docs
- [ ] Updated editor guidelines (See https://intranet.torchbox.com/torchbox-com-project-docs for the private link, for Torchbox employees only)
- [ ] Updated field spec (See https://intranet.torchbox.com/torchbox-com-project-docs for the private link, for Torchbox employees only)
- [x] Not required

#### Browser testing

- [ ] I have tested in the following browsers and environments (edit the list as required)
  - Latest version of Chrome on mac
  - Latest version of Firefox on mac
  - Latest version of Safari on mac
  - Safari on last two versions of iOS
  - Chrome on last two versions of Android
- [x] Not required

#### Data protection

- [x] Not relevant
- [ ] This adds new sources of PII and documents it and modifies Birdbath processors accordingly

#### Light and dark mode

- [ ] I have tested the changes in both light and dark mode
- [x] The change is not relevant to dark and light mode

#### Accessibility

- [ ] Automated WCAG 2.1 tests pass
- [ ] HTML validation passes
- [ ] Manual WCAG 2.1 tests completed
- [ ] I have tested in a screen reader
- [ ] I have tested in high-contrast mode
- [ ] Any animations removed for prefers-reduced-motion
- [x] Not required

#### Sustainability

- [ ] Images are optimised and lazy-loading used where appropriate
- [ ] SVGs have been optimised
- [ ] Performance and transfer of data considered
- [ ] If JavaScript is needed alternatives have been considered
- [x] Not required

#### Pattern library

- [x] The pattern library component for this template displays correctly, and does not break parent templates
- [x] The styleguide is updated if relevant
- [ ] Changes are not relevant the pattern library
