### PR TITLE
Fix RelatedBlogPage DoesNotExist error in reference index task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file. This projec
 
 Add your changes to the Unreleased section and move them to the appropriate section when they are merged.
 
+## 2026-05-21
+
+- [TWE-711](https://torchbox.atlassian.net/browse/TWE-711) - Fix RelatedBlog error edge case
+
 ## 2026-05-13
 
 - Fix 500 error on pages where a referenced page in a chooser block has been deleted

--- a/tbx/blog/models.py
+++ b/tbx/blog/models.py
@@ -276,6 +276,9 @@ class BlogPage(BasePage):
 
 
 class RelatedBlogPage(models.Model):
+    # Prevent DoesNotExist in update_reference_index_task; BlogPage's own update captures these references.
+    wagtail_reference_index_ignore = True
+
     parent = ParentalKey(
         BlogPage, on_delete=models.CASCADE, related_name="related_posts"
     )


### PR DESCRIPTION
## Summary

- Adds `wagtail_reference_index_ignore = True` to `RelatedBlogPage` to opt it out of Wagtail's per-object reference index tracking
- Fixes a `RelatedBlogPage.DoesNotExist` error raised by `update_reference_index_task` on every blog page save

## Background

When a `BlogPage` is saved, modelcluster deletes old `RelatedBlogPage` inline rows and recreates them within the same transaction. Wagtail's `post_save` signal enqueues `update_reference_index_task` for each `RelatedBlogPage`, but `ImmediateBackend` defers execution via `transaction.on_commit`. By the time `on_commit` fires, the old rows are gone and `model.objects.get(pk=pk)` raises `DoesNotExist`.

Setting `wagtail_reference_index_ignore = True` prevents the signal from being connected for `RelatedBlogPage`. References from `RelatedBlogPage.page` are still captured correctly: `ReferenceIndex._extract_references_from_object` already scans all ParentalKey child objects when indexing the parent `BlogPage`.

## Test plan

- [ ] Confirm existing blog tests pass
- [ ] Edit a blog page with related posts in staging and verify no `RelatedBlogPage.DoesNotExist` errors appear in logs
- [ ] Check that the "Where is this referenced?" feature in the Wagtail admin still shows correct results for pages used as related posts

Fixes TWE-711