### PR TITLE
AHJM-405 Bump Django to security release 5.2.15

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -585,13 +585,13 @@ Django = ">=4.2"
 
 [[package]]
 name = "django"
-version = "5.2.12"
+version = "5.2.15"
 description = "A high-level Python web framework that encourages rapid development and clean, pragmatic design."
 optional = false
 python-versions = ">=3.10"
 files = [
-    {file = "django-5.2.12-py3-none-any.whl", hash = "sha256:4853482f395c3a151937f6991272540fcbf531464f254a347bf7c89f53c8cff7"},
-    {file = "django-5.2.12.tar.gz", hash = "sha256:6b809af7165c73eff5ce1c87fdae75d4da6520d6667f86401ecf55b681eb1eeb"},
+    {file = "django-5.2.15-py3-none-any.whl", hash = "sha256:0eb4a9bb1853a35b0286dbc6d916bd352c8c2687195a7f2d6f80cefd840e4970"},
+    {file = "django-5.2.15.tar.gz", hash = "sha256:5154a9bf84ac01dde011e367f355c07dbb329532e06810dcf3ef2af269e236e7"},
 ]
 
 [package.dependencies]


### PR DESCRIPTION
Not doing any non-django upgrades here as they are covered in the Wagtail 7.4 upgrade currently on staging.