### PR TITLE
Fix primary nav performance and keyboard accessibility issues

### DIFF
--- a/tbx/project_styleguide/templates/patterns/navigation/components/primary-nav.html
+++ b/tbx/project_styleguide/templates/patterns/navigation/components/primary-nav.html
@@ -1,3 +1,6 @@
+{# This markup is re-created in desktop-close-menus.test.js — if you change #}
+{# classes/attributes here (eg. data-has-subnav, data-open-primary-subnav, #}
+{# aria-expanded), update that test fixture too. #}
 {% for nav_item in nav_items %}
     {% with item=nav_item.item is_current=nav_item.is_current %}
         <li class="primary-nav-desktop__item{% if item.style != "none" %} primary-nav-desktop__item--has-children{% endif %}{% if is_current %} primary-nav-desktop__item--current{% endif %}"{% if item.style != "none" %} data-has-subnav{% endif %}>

--- a/tbx/project_styleguide/templates/patterns/organisms/header/header.html
+++ b/tbx/project_styleguide/templates/patterns/organisms/header/header.html
@@ -21,6 +21,9 @@
             </div>
 
             {# Primary desktop navigation #}
+            {# This markup is re-created in desktop-close-menus.test.js — if you change #}
+            {# data-primary-desktop-menu or the backdrop/mobile-menu classes it checks, #}
+            {# update that test fixture too. #}
             <nav aria-label="Main navigation" class="primary-nav-desktop" data-primary-desktop-menu>
                 <ul class="primary-nav-desktop__list">
                     {% primarynav %}

--- a/tbx/static_src/javascript/components/desktop-close-menus.js
+++ b/tbx/static_src/javascript/components/desktop-close-menus.js
@@ -37,13 +37,16 @@ class DesktopCloseMenus {
         }
     }
 
-    // Close desktop menus when clicking on document
-    closeMenus(e) {
-        let close = true;
+    isOutsideNav(target) {
+        if (!target) {
+            return true;
+        }
+
+        let outside = true;
 
         this.allPrimaryNavs.forEach((item) => {
-            if (item.contains(e.target)) {
-                close = false;
+            if (item.contains(target)) {
+                outside = false;
             }
         });
 
@@ -51,10 +54,22 @@ class DesktopCloseMenus {
             this.primaryMobileNav &&
             this.primaryMobileNav.classList.contains('is-visible')
         ) {
-            close = false;
+            outside = false;
         }
 
-        if (close) {
+        return outside;
+    }
+
+    // Close desktop menus when clicking on document
+    closeMenus(e) {
+        if (this.isOutsideNav(e.target)) {
+            this.closeDesktopMenus();
+        }
+    }
+
+    // Close desktop menus when focus (eg. via Tab) moves outside them
+    closeMenusOnFocusOut(e) {
+        if (this.isOutsideNav(e.relatedTarget)) {
             this.closeDesktopMenus();
         }
     }
@@ -69,6 +84,10 @@ class DesktopCloseMenus {
 
         document.addEventListener('click', (e) => {
             this.closeMenus(e);
+        });
+
+        document.addEventListener('focusout', (e) => {
+            this.closeMenusOnFocusOut(e);
         });
 
         document.addEventListener('keydown', (event) => {

--- a/tbx/static_src/javascript/components/desktop-close-menus.js
+++ b/tbx/static_src/javascript/components/desktop-close-menus.js
@@ -86,8 +86,10 @@ class DesktopCloseMenus {
             this.closeMenus(e);
         });
 
-        document.addEventListener('focusout', (e) => {
-            this.closeMenusOnFocusOut(e);
+        this.allPrimaryNavs.forEach((nav) => {
+            nav.addEventListener('focusout', (e) => {
+                this.closeMenusOnFocusOut(e);
+            });
         });
 
         document.addEventListener('keydown', (event) => {

--- a/tbx/static_src/javascript/components/desktop-close-menus.test.js
+++ b/tbx/static_src/javascript/components/desktop-close-menus.test.js
@@ -7,11 +7,6 @@ describe('DesktopCloseMenus', () => {
     // instantiated once here rather than per test. classList/aria state is
     // reset in beforeEach instead of recreating the DOM.
     beforeAll(() => {
-        // This markup mirrors patterns/organisms/header/header.html and
-        // patterns/navigation/components/primary-nav.html. If you change the
-        // classes/attributes those templates use (eg. data-has-subnav,
-        // data-open-primary-subnav, data-primary-subnav, aria-expanded),
-        // update this fixture too.
         document.body.innerHTML = `
             <nav aria-label="Main navigation" class="primary-nav-desktop" data-primary-desktop-menu>
                 <ul class="primary-nav-desktop__list">

--- a/tbx/static_src/javascript/components/desktop-close-menus.test.js
+++ b/tbx/static_src/javascript/components/desktop-close-menus.test.js
@@ -1,0 +1,158 @@
+import DesktopCloseMenus from './desktop-close-menus';
+import PrimaryDesktopSubMenu from './primary-desktop-sub-menu';
+
+describe('DesktopCloseMenus', () => {
+    // DesktopCloseMenus binds document-level click/focusout/keydown
+    // listeners for the lifetime of the page, so — as in production — it's
+    // instantiated once here rather than per test. classList/aria state is
+    // reset in beforeEach instead of recreating the DOM.
+    beforeAll(() => {
+        document.body.innerHTML = `
+            <nav aria-label="Main navigation" class="primary-nav-desktop" data-primary-desktop-menu>
+                <ul class="primary-nav-desktop__list">
+                    <li class="primary-nav-desktop__item primary-nav-desktop__item--has-children" data-has-subnav>
+                        <button
+                            class="primary-nav-desktop__link primary-nav-desktop__link--has-children"
+                            data-open-primary-subnav
+                            aria-expanded="false"
+                            aria-controls="primary-nav-dropdown-1"
+                        >
+                            Services
+                        </button>
+                        <div class="primary-nav-dropdown" id="primary-nav-dropdown-1" data-primary-subnav>
+                            <a href="/services/design/" class="primary-nav-dropdown__row-link">Design</a>
+                            <a href="/services/strategy/" class="primary-nav-dropdown__row-link">Strategy</a>
+                        </div>
+                    </li>
+                </ul>
+            </nav>
+            <div class="primary-nav-dropdown-backdrop" data-primary-nav-dropdown-backdrop aria-hidden="true"></div>
+            <main>
+                <a href="/about/" id="page-content-link">About</a>
+            </main>
+        `;
+
+        document
+            .querySelectorAll(PrimaryDesktopSubMenu.selector())
+            .forEach((node) => new PrimaryDesktopSubMenu(node));
+
+        // eslint-disable-next-line no-new
+        new DesktopCloseMenus();
+    });
+
+    beforeEach(() => {
+        document.querySelector('[data-has-subnav]').classList.remove('active');
+        document
+            .querySelector('[data-open-primary-subnav]')
+            .setAttribute('aria-expanded', 'false');
+        document.body.classList.remove(
+            'no-scroll',
+            'primary-nav-dropdown-open',
+        );
+        document
+            .querySelector('[data-primary-nav-dropdown-backdrop]')
+            .setAttribute('aria-hidden', 'true');
+        document.body.focus();
+    });
+
+    const openDropdown = () => {
+        document
+            .querySelector('[data-open-primary-subnav]')
+            .dispatchEvent(new Event('click', { bubbles: true }));
+    };
+
+    it('opens the dropdown on click', () => {
+        openDropdown();
+
+        expect(document.querySelector('[data-has-subnav]').classList).toContain(
+            'active',
+        );
+        expect(document.body.classList).toContain('primary-nav-dropdown-open');
+    });
+
+    it('closes the dropdown when focus tabs past the last link inside it', () => {
+        openDropdown();
+
+        const strategyLink = document.querySelector(
+            'a[href="/services/strategy/"]',
+        );
+        const outsideLink = document.getElementById('page-content-link');
+        strategyLink.focus();
+
+        strategyLink.dispatchEvent(
+            new FocusEvent('focusout', {
+                bubbles: true,
+                relatedTarget: outsideLink,
+            }),
+        );
+
+        expect(
+            document.querySelector('[data-has-subnav]').classList,
+        ).not.toContain('active');
+        expect(
+            document
+                .querySelector('[data-open-primary-subnav]')
+                .getAttribute('aria-expanded'),
+        ).toBe('false');
+        expect(document.body.classList).not.toContain(
+            'primary-nav-dropdown-open',
+        );
+        expect(document.body.classList).not.toContain('no-scroll');
+        expect(
+            document
+                .querySelector('[data-primary-nav-dropdown-backdrop]')
+                .getAttribute('aria-hidden'),
+        ).toBe('true');
+    });
+
+    it('keeps the dropdown open when focus moves between links inside it', () => {
+        openDropdown();
+
+        const designLink = document.querySelector(
+            'a[href="/services/design/"]',
+        );
+        const strategyLink = document.querySelector(
+            'a[href="/services/strategy/"]',
+        );
+        designLink.focus();
+
+        designLink.dispatchEvent(
+            new FocusEvent('focusout', {
+                bubbles: true,
+                relatedTarget: strategyLink,
+            }),
+        );
+
+        expect(document.querySelector('[data-has-subnav]').classList).toContain(
+            'active',
+        );
+        expect(document.body.classList).toContain('primary-nav-dropdown-open');
+    });
+
+    it('closes the dropdown when clicking outside it', () => {
+        openDropdown();
+
+        document
+            .getElementById('page-content-link')
+            .dispatchEvent(new Event('click', { bubbles: true }));
+
+        expect(
+            document.querySelector('[data-has-subnav]').classList,
+        ).not.toContain('active');
+        expect(document.body.classList).not.toContain(
+            'primary-nav-dropdown-open',
+        );
+    });
+
+    it('closes the dropdown on Escape', () => {
+        openDropdown();
+
+        document.dispatchEvent(
+            new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }),
+        );
+
+        expect(
+            document.querySelector('[data-has-subnav]').classList,
+        ).not.toContain('active');
+    });
+});

--- a/tbx/static_src/javascript/components/desktop-close-menus.test.js
+++ b/tbx/static_src/javascript/components/desktop-close-menus.test.js
@@ -7,6 +7,11 @@ describe('DesktopCloseMenus', () => {
     // instantiated once here rather than per test. classList/aria state is
     // reset in beforeEach instead of recreating the DOM.
     beforeAll(() => {
+        // This markup mirrors patterns/organisms/header/header.html and
+        // patterns/navigation/components/primary-nav.html. If you change the
+        // classes/attributes those templates use (eg. data-has-subnav,
+        // data-open-primary-subnav, data-primary-subnav, aria-expanded),
+        // update this fixture too.
         document.body.innerHTML = `
             <nav aria-label="Main navigation" class="primary-nav-desktop" data-primary-desktop-menu>
                 <ul class="primary-nav-desktop__list">

--- a/tbx/static_src/javascript/components/focus-trap.js
+++ b/tbx/static_src/javascript/components/focus-trap.js
@@ -8,13 +8,21 @@ const FOCUSABLE_SELECTOR = [
 ].join(', ');
 
 function isElementVisible(element) {
+    // A parent can be hidden while a child sets itself visible again —
+    // the browser handles that automatically, so just ask the element
+    // directly instead of checking every parent by hand. The mobile nav
+    // does exactly this: an inactive item's <li> is hidden, but its open
+    // submenu panel resets itself back to visible.
+    if (window.getComputedStyle(element).visibility === 'hidden') {
+        return false;
+    }
+
     let node = element;
 
     while (node) {
         const style = window.getComputedStyle(node);
 
         if (
-            style.visibility === 'hidden' ||
             style.display === 'none' ||
             node.getAttribute('aria-hidden') === 'true'
         ) {

--- a/tbx/static_src/javascript/components/focus-trap.test.js
+++ b/tbx/static_src/javascript/components/focus-trap.test.js
@@ -56,6 +56,40 @@ describe('focus-trap', () => {
             ).toEqual(['About', 'Contact', 'Hidden back']);
         });
 
+        it('treats an element as visible when it overrides a hidden ancestor', () => {
+            // Mirrors the mobile nav: the open subnav's containing <li> is
+            // set visibility: hidden (to hide inactive top-level items),
+            // but the subnav panel itself re-asserts visibility: visible —
+            // CSS inheritance means its contents render fine, so the
+            // default visibility check must resolve the same way rather
+            // than rejecting them for their ancestor's hidden value.
+            document.body.innerHTML = `
+                <li style="visibility: hidden;">
+                    <div style="visibility: visible;">
+                        <a href="/design/">Design</a>
+                    </div>
+                </li>
+            `;
+
+            const li = document.querySelector('li');
+
+            expect(
+                getFocusableElements([li]).map((el) => el.textContent),
+            ).toEqual(['Design']);
+        });
+
+        it('excludes an element with no visible override under a hidden ancestor', () => {
+            document.body.innerHTML = `
+                <li style="visibility: hidden;">
+                    <a href="/design/">Design</a>
+                </li>
+            `;
+
+            const li = document.querySelector('li');
+
+            expect(getFocusableElements([li])).toEqual([]);
+        });
+
         it('includes focusable elements inside visible subnav panels', () => {
             document
                 .getElementById('hidden-subnav')

--- a/tbx/static_src/javascript/components/primary-mobile-sub-menu.js
+++ b/tbx/static_src/javascript/components/primary-mobile-sub-menu.js
@@ -1,3 +1,5 @@
+import { trapFocus } from './focus-trap';
+
 class PrimaryMobileSubMenu {
     static selector() {
         return '[data-primary-mobile-menu] [data-open-primary-subnav]';
@@ -29,6 +31,15 @@ class PrimaryMobileSubMenu {
         this.backLink.addEventListener('click', (e) => {
             e.preventDefault();
             this.close();
+        });
+
+        // Trap the focus inside the submenu while it's open
+        document.addEventListener('keydown', (event) => {
+            if (!this.subnav.classList.contains('is-visible')) {
+                return;
+            }
+
+            trapFocus(event, [this.subnav]);
         });
     }
 

--- a/tbx/static_src/javascript/components/primary-mobile-sub-menu.test.js
+++ b/tbx/static_src/javascript/components/primary-mobile-sub-menu.test.js
@@ -55,6 +55,79 @@ describe('PrimaryMobileSubMenu', () => {
         ).toBe('primary-nav-mobile');
     });
 
+    it('loops focus from the last item back to the back button on Tab', () => {
+        // eslint-disable-next-line no-new
+        new PrimaryMobileSubMenu(
+            document.querySelector(PrimaryMobileSubMenu.selector()),
+        );
+
+        document
+            .querySelector('[data-open-primary-subnav]')
+            .dispatchEvent(new Event('click'));
+
+        const lastLink = document.querySelector('a[href="/services/"]');
+        const back = document.querySelector('[data-primary-subnav-back]');
+        lastLink.focus();
+
+        const tabEvent = new KeyboardEvent('keydown', {
+            key: 'Tab',
+            bubbles: true,
+            cancelable: true,
+        });
+        document.dispatchEvent(tabEvent);
+
+        expect(tabEvent.defaultPrevented).toBe(true);
+        expect(document.activeElement).toBe(back);
+    });
+
+    it('loops focus from the back button to the last item on Shift+Tab', () => {
+        // eslint-disable-next-line no-new
+        new PrimaryMobileSubMenu(
+            document.querySelector(PrimaryMobileSubMenu.selector()),
+        );
+
+        document
+            .querySelector('[data-open-primary-subnav]')
+            .dispatchEvent(new Event('click'));
+
+        const lastLink = document.querySelector('a[href="/services/"]');
+        const back = document.querySelector('[data-primary-subnav-back]');
+        back.focus();
+
+        const tabEvent = new KeyboardEvent('keydown', {
+            key: 'Tab',
+            shiftKey: true,
+            bubbles: true,
+            cancelable: true,
+        });
+        document.dispatchEvent(tabEvent);
+
+        expect(tabEvent.defaultPrevented).toBe(true);
+        expect(document.activeElement).toBe(lastLink);
+    });
+
+    it('does not trap focus once the subnav is closed', () => {
+        // eslint-disable-next-line no-new
+        new PrimaryMobileSubMenu(
+            document.querySelector(PrimaryMobileSubMenu.selector()),
+        );
+
+        const trigger = document.querySelector('[data-open-primary-subnav]');
+        trigger.dispatchEvent(new Event('click'));
+        document
+            .querySelector('[data-primary-subnav-back]')
+            .dispatchEvent(new Event('click'));
+
+        const tabEvent = new KeyboardEvent('keydown', {
+            key: 'Tab',
+            bubbles: true,
+            cancelable: true,
+        });
+        document.dispatchEvent(tabEvent);
+
+        expect(tabEvent.defaultPrevented).toBe(false);
+    });
+
     it('does not throw when aria-controls is missing', () => {
         document.body.innerHTML = `
             <nav class="primary-nav-mobile" data-primary-mobile-menu>

--- a/tbx/static_src/sass/base/_base.scss
+++ b/tbx/static_src/sass/base/_base.scss
@@ -8,6 +8,9 @@ html {
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
     scroll-behavior: smooth;
+    // Reserve the scrollbar's width permanently so toggling `.no-scroll`
+    // (nav dropdowns, modals) never shifts layout width mid-transition.
+    scrollbar-gutter: stable;
 
     @media (prefers-reduced-motion: reduce) {
         scroll-behavior: auto;

--- a/tbx/static_src/sass/components/_header.scss
+++ b/tbx/static_src/sass/components/_header.scss
@@ -42,8 +42,14 @@
 
         @include media-query(menu) {
             align-items: stretch;
-            gap: $spacer-small-plus;
+            flex-wrap: wrap;
+            gap: 10px;
             padding: $spacer-small 0;
+        }
+
+        @include media-query(x-large) {
+            flex-wrap: nowrap;
+            gap: $spacer-mini-plus;
         }
     }
 

--- a/tbx/static_src/sass/components/_header.scss
+++ b/tbx/static_src/sass/components/_header.scss
@@ -10,11 +10,11 @@
         border-bottom-color: var(--color--light-border);
     }
 
-    body.primary-nav-dropdown-open &,
-    body:has(.primary-nav-desktop__item.active) & {
-        @include media-query(menu) {
-            @include z-index(header-controls);
-        }
+    // Always stay above the dropdown/backdrop at this breakpoint. Toggling
+    // this only while open caused the header to duck below them mid
+    // fade-out, since the class is removed before they finish fading.
+    @include media-query(menu) {
+        @include z-index(header-controls);
     }
 
     &--mobile-menu-open {

--- a/tbx/static_src/sass/components/_logo.scss
+++ b/tbx/static_src/sass/components/_logo.scss
@@ -50,9 +50,14 @@
             height: 30px;
         }
 
-        @include media-query(large) {
-            width: 436px;
-            height: 39px;
+        @include media-query(menu) {
+            width: 280px;
+            height: 30px;
+        }
+
+        @include media-query(x-large) {
+            width: 366px;
+            height: 30px;
         }
     }
 }

--- a/tbx/static_src/sass/components/navigation/_primary-nav-desktop.scss
+++ b/tbx/static_src/sass/components/navigation/_primary-nav-desktop.scss
@@ -13,10 +13,14 @@ Styles for the primary navigation at desktop (top level)
     @include media-query(menu) {
         display: flex;
         align-items: stretch;
-        margin-left: $spacer-small;
+        order: 10;
+        flex-basis: 100%;
+        margin-left: 0;
     }
 
-    @include media-query(large) {
+    @include media-query(x-large) {
+        order: 0;
+        flex: 1;
         margin-left: $spacer-medium;
     }
 
@@ -31,9 +35,10 @@ Styles for the primary navigation at desktop (top level)
         @include media-query(menu) {
             height: 100%;
             align-items: stretch;
+            gap: $spacer-mini-plus;
         }
 
-        @include media-query(large) {
+        @include media-query(x-large) {
             gap: $spacer-small-plus;
         }
     }

--- a/tbx/static_src/sass/components/navigation/_primary-nav-desktop.scss
+++ b/tbx/static_src/sass/components/navigation/_primary-nav-desktop.scss
@@ -13,7 +13,7 @@ Styles for the primary navigation at desktop (top level)
     @include media-query(menu) {
         display: flex;
         align-items: stretch;
-        order: 10;
+        order: 1;
         flex-basis: 100%;
         margin-left: 0;
     }

--- a/tbx/static_src/sass/components/navigation/_primary-nav-desktop.scss
+++ b/tbx/static_src/sass/components/navigation/_primary-nav-desktop.scss
@@ -35,7 +35,7 @@ Styles for the primary navigation at desktop (top level)
         @include media-query(menu) {
             height: 100%;
             align-items: stretch;
-            gap: $spacer-mini-plus;
+            gap: $spacer-small;
         }
 
         @include media-query(x-large) {

--- a/tbx/static_src/sass/components/navigation/_primary-nav-dropdown-backdrop.scss
+++ b/tbx/static_src/sass/components/navigation/_primary-nav-dropdown-backdrop.scss
@@ -1,9 +1,10 @@
 @use '../../config' as *;
 
 /*
-Fixed overlay behind open desktop dropdowns. Clicks pass through to
-document listeners; the tint and backdrop blur sit above page content while
-the dropdown panel itself stays transparent.
+Dims and blurs the page behind an open desktop dropdown. Clicks pass
+through to document listeners rather than being caught here. Kept as
+one fixed-size layer covering just the viewport, rather than blurring
+the page content itself, so the blur stays cheap to render.
 */
 .primary-nav-dropdown-backdrop {
     display: none;
@@ -13,7 +14,7 @@ the dropdown panel itself stays transparent.
         display: block;
         position: fixed;
         inset: 0;
-        background: rgb(0 0 0 / 0.22);
+        background: rgb(0 0 0 / 0.55);
         backdrop-filter: blur($nav-dropdown-blur);
         opacity: 0;
         visibility: hidden;
@@ -38,29 +39,6 @@ the dropdown panel itself stays transparent.
             transition:
                 opacity $transition 50ms,
                 visibility 0ms;
-        }
-    }
-}
-
-// Blur page content when a desktop dropdown is open. The dropdown shell is
-// transparent so this remains visible; the backdrop adds a tint on top.
-@include media-query(menu) {
-    .breadcrumbs-nav,
-    .page {
-        transition: filter $transition;
-
-        @include reduced-motion() {
-            transition: none;
-        }
-    }
-}
-
-body.primary-nav-dropdown-open,
-body:has(.primary-nav-desktop__item.active) {
-    @include media-query(menu) {
-        .breadcrumbs-nav,
-        .page {
-            filter: blur($nav-dropdown-blur);
         }
     }
 }

--- a/tbx/static_src/sass/components/navigation/_primary-nav-dropdown-mobile.scss
+++ b/tbx/static_src/sass/components/navigation/_primary-nav-dropdown-mobile.scss
@@ -23,6 +23,15 @@ Styles for primary navigation dropdown panels at mobile
     &.is-visible {
         visibility: visible;
         opacity: 1;
+        // Become visible with no delay — JS focuses the back button right
+        // away, and a hidden element can't be focused yet.
+        transition:
+            visibility 0ms ease-out,
+            opacity 250ms ease-out 50ms;
+
+        @include reduced-motion() {
+            transition: none;
+        }
     }
 
     &__list {

--- a/tbx/static_src/sass/components/navigation/_primary-nav-dropdown-mobile.scss
+++ b/tbx/static_src/sass/components/navigation/_primary-nav-dropdown-mobile.scss
@@ -79,6 +79,7 @@ Styles for primary navigation dropdown panels at mobile
 
         &:focus-visible {
             @include focus-style();
+            outline-offset: -3px;
         }
 
         &--back {

--- a/tbx/static_src/sass/components/navigation/_primary-nav-dropdown.scss
+++ b/tbx/static_src/sass/components/navigation/_primary-nav-dropdown.scss
@@ -32,7 +32,8 @@ Styles for primary navigation dropdown panels at desktop
     }
 
     @include media-query(menu) {
-        top: $header-full-height + 34px;
+        // Extra top offset for dropdowns at the `menu` breakpoint, where the nav sits below the logo.
+        top: $header-full-height + $nav-dropdown-menu-breakpoint-offset;
         max-height: calc(100vh - #{$header-full-height});
         max-height: calc(100dvh - #{$header-full-height});
     }

--- a/tbx/static_src/sass/components/navigation/_primary-nav-dropdown.scss
+++ b/tbx/static_src/sass/components/navigation/_primary-nav-dropdown.scss
@@ -32,11 +32,12 @@ Styles for primary navigation dropdown panels at desktop
     }
 
     @include media-query(menu) {
+        top: $header-full-height + 34px;
         max-height: calc(100vh - #{$header-full-height});
         max-height: calc(100dvh - #{$header-full-height});
     }
 
-    @include media-query(large) {
+    @include media-query(x-large) {
         top: $header-full-height-large;
         max-height: calc(100vh - #{$header-full-height-large});
         max-height: calc(100dvh - #{$header-full-height-large});

--- a/tbx/static_src/sass/components/navigation/_primary-nav-dropdown.scss
+++ b/tbx/static_src/sass/components/navigation/_primary-nav-dropdown.scss
@@ -12,9 +12,24 @@ Styles for primary navigation dropdown panels at desktop
         $header-height: $header-full-height,
         $full-height: false
     );
+    // Extend the mixin's visibility/opacity transition to also cover
+    // background-color and box-shadow — otherwise those snap instantly
+    // on close while the panel is still rendered (opacity/visibility
+    // haven't finished fading), leaving a bare, colourless panel
+    // visible for a moment: reads as a flash.
+    transition:
+        visibility 0ms ease-out 50ms,
+        opacity $transition 50ms,
+        background-color $transition 50ms,
+        box-shadow $transition 50ms;
     background-color: transparent;
+    box-shadow: none;
     border: 0;
     padding: 0;
+
+    @include reduced-motion() {
+        transition: none;
+    }
 
     @include media-query(menu) {
         max-height: calc(100vh - #{$header-full-height});
@@ -31,7 +46,6 @@ Styles for primary navigation dropdown panels at desktop
         opacity: 1;
         visibility: visible;
         background-color: color.adjust($color--eclipse, $alpha: -0.06);
-        backdrop-filter: blur(16px);
         box-shadow: 0 8px 32px rgb(0 0 0 / 0.15);
 
         .mode-light & {

--- a/tbx/static_src/sass/components/navigation/_primary-nav-mobile.scss
+++ b/tbx/static_src/sass/components/navigation/_primary-nav-mobile.scss
@@ -92,6 +92,7 @@ Styles for the primary navigation at mobile (top level)
 
         &:focus-visible {
             @include focus-style();
+            outline-offset: -3px;
         }
     }
 

--- a/tbx/static_src/sass/config/_variables.scss
+++ b/tbx/static_src/sass/config/_variables.scss
@@ -438,3 +438,4 @@ $header-full-height: (
 $header-full-height-large: ($spacer-small * 2 + 39px);
 $nav-dropdown-blur: 20px;
 $nav-dropdown-header-gap: 40px;
+$nav-dropdown-menu-breakpoint-offset: 34px;


### PR DESCRIPTION
### Description of Changes Made

#### Summary
- Fixes a cluster of issues in the desktop and mobile primary navigation: laggy dropdown animations, focus getting lost or stuck when using the keyboard, and the header wrapping badly on tablet-sized viewports.

#### Changes
##### Performance

- Fixed a laggy dropdown open/close transition and a visual flash on close, caused by animating expensive properties (box-shadow, background-color) alongside cheap ones (opacity) without them being in sync.
- Fixed the header briefly disappearing behind the dropdown backdrop when closing a menu, caused by a z-index change firing before the close transition had finished.

<details>
  <summary>Before</summary>

https://github.com/user-attachments/assets/5957b553-23eb-4c6a-b4f4-7cfe576132cf

</details>

<details>
  <summary>After</summary>

https://github.com/user-attachments/assets/056a0063-69b5-4ccb-9333-cca196d590a3

</details>

##### Keyboard accessibility

- Desktop nav dropdowns now close when focus tabs outside them, instead of leaving an open (but invisible) dropdown behind while the user tabs into page content.

<details>
  <summary>Mobile fixes</summary>

https://github.com/user-attachments/assets/b5af3273-451a-411a-930e-8253e2ae6c81

</details>

- Fixed a mobile submenu bug where opening a subnav didn't move focus to its "Back" button, because the panel was still visibility: hidden at the exact moment JS tried to focus it.
- Added a focus trap to mobile submenus so tabbing through one loops back to the "Back" button instead of escaping into the page behind it.
- Fixed the focus ring visibility on mobile menu items.

<details>
  <summary>Mobile fixes</summary>

https://github.com/user-attachments/assets/c0d4a64f-4039-457f-8bb3-b02b98139860

</details>

##### Layout

- Fixed the header wrapping awkwardly on viewports between tablet-portrait and desktop sizes, where the logo (particularly the Wagtail lockup, considerably wider than other variants) left too little room for the nav — the nav now drops to its own row under the logo in that range.

<details>
  <summary>Wrap logo fix screen</summary>

<img width="831" height="887" alt="image" src="https://github.com/user-attachments/assets/2c1a24e9-ce88-42c3-8660-0814197abbb8" />

<img width="830" height="714" alt="image" src="https://github.com/user-attachments/assets/deaabad6-cf6e-4479-a923-13e5eee3ba61" />


</details>

##### Testing
- Added/extended Jest coverage for the desktop close-on-focus-out behaviour, the mobile submenu focus trap, and the focus-trap utility itself.

### MR Checklist

- [x] Add a description of your pull request and instructions for the reviewer to verify your work.
- [ ] If your pull request is for a specific ticket, link to it in the description.
- [x] Stay on point and keep it small so the merge request can be easily reviewed.
- [x] Tests and linting passes.

#### Unit tests

- [ ] Added
- [ ] Not required

#### Documentation

- [ ] Updated build docs
- [ ] Updated editor guidelines (See https://intranet.torchbox.com/torchbox-com-project-docs for the private link, for Torchbox employees only)
- [ ] Updated field spec (See https://intranet.torchbox.com/torchbox-com-project-docs for the private link, for Torchbox employees only)
- [ ] Not required

#### Browser testing

- [x] I have tested in the following browsers and environments (edit the list as required)
  - Latest version of Chrome on mac
  - Latest version of Firefox on mac
  - Latest version of Safari on mac
  - Safari on last two versions of iOS
  - Chrome on last two versions of Android
- [ ] Not required

#### Data protection

- [x] Not relevant
- [ ] This adds new sources of PII and documents it and modifies Birdbath processors accordingly

#### Light and dark mode

- [x] I have tested the changes in both light and dark mode
- [ ] The change is not relevant to dark and light mode

#### Accessibility

- [ ] Automated WCAG 2.1 tests pass
- [ ] HTML validation passes
- [ ] Manual WCAG 2.1 tests completed
- [ ] I have tested in a screen reader
- [ ] I have tested in high-contrast mode
- [ ] Any animations removed for prefers-reduced-motion
- [ ] Not required

#### Sustainability

- [ ] Images are optimised and lazy-loading used where appropriate
- [ ] SVGs have been optimised
- [ ] Performance and transfer of data considered
- [ ] If JavaScript is needed alternatives have been considered
- [ ] Not required

#### Pattern library

- [ ] The pattern library component for this template displays correctly, and does not break parent templates
- [ ] The styleguide is updated if relevant
- [ ] Changes are not relevant the pattern library
