### PR TITLE
Add management command to delete redirects to torchbox.com on staging

### DIFF
--- a/tbx/core/management/commands/find_torchbox_redirects.py
+++ b/tbx/core/management/commands/find_torchbox_redirects.py
@@ -1,0 +1,48 @@
+import os
+
+from django.core.management.base import BaseCommand, CommandError
+
+from wagtail.contrib.redirects.models import Redirect
+
+
+TORCHBOX_DOMAIN = "https://torchbox.com"
+
+
+class Command(BaseCommand):
+    help = "Find Wagtail redirects that point to a torchbox.com URL"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--delete",
+            action="store_true",
+            help="Delete the matching redirects instead of just listing them",
+        )
+
+    def handle(self, *args, **options):
+        sentry_env = os.environ.get("SENTRY_ENVIRONMENT", "")
+        if sentry_env == "production":
+            raise CommandError(
+                "This command cannot be run in the production environment."
+            )
+
+        qs = Redirect.objects.filter(redirect_link__icontains=TORCHBOX_DOMAIN)
+        matches = list(qs.values_list("old_path", "redirect_link"))
+
+        if not matches:
+            self.stdout.write("No redirects pointing to torchbox.com were found.")
+            return
+
+        self.stdout.write(
+            f"Found {len(matches)} redirect(s) pointing to torchbox.com:\n"
+        )
+        for old_path, redirect_link in matches:
+            self.stdout.write(f"  {old_path}  →  {redirect_link}")
+
+        if options["delete"]:
+            qs.delete()
+            self.stdout.write(self.style.SUCCESS("\nDeleted redirects:"))
+            for old_path, redirect_link in matches:
+                self.stdout.write(
+                    self.style.SUCCESS(f"  {old_path}  →  {redirect_link}")
+                )
+            self.stdout.write(self.style.SUCCESS(f"\nTotal deleted: {len(matches)}"))


### PR DESCRIPTION
### Description of Changes Made


On staging we have a bunch of redirects which all point to a torchbox.com url. This is as a result of importing the production data. It's potentially very confusing, as people might not notice the redirect - and in a worst case scenario they might accidentally edit a live page with a test thinking they are on staging. This PR adds a management command that allows you to delete all redirects pointing to a `http://torchbox.com` url. At the moment it excludes any media.torchbox.com redirects.

### How to Test

Try running the script in your local build. Note that as a precaution it can't be run in production.

### Screenshots

<details>
  <summary>Expand to see more</summary>

</details>

### MR Checklist

- [x] Add a description of your pull request and instructions for the reviewer to verify your work.
- [ ] If your pull request is for a specific ticket, link to it in the description.
- [x] Stay on point and keep it small so the merge request can be easily reviewed.
- [x] Tests and linting passes.

#### Unit tests

- [ ] Added
- [x] Not required

#### Documentation

- [ ] Updated build docs
- [ ] Updated editor guidelines (See https://intranet.torchbox.com/torchbox-com-project-docs for the private link, for Torchbox employees only)
- [ ] Updated field spec (See https://intranet.torchbox.com/torchbox-com-project-docs for the private link, for Torchbox employees only)
- [x] Not required

#### Browser testing

- [ ] I have tested in the following browsers and environments (edit the list as required)
  - Latest version of Chrome on mac
  - Latest version of Firefox on mac
  - Latest version of Safari on mac
  - Safari on last two versions of iOS
  - Chrome on last two versions of Android
- [x] Not required

#### Data protection

- [x] Not relevant
- [ ] This adds new sources of PII and documents it and modifies Birdbath processors accordingly

#### Light and dark mode

- [ ] I have tested the changes in both light and dark mode
- [x] The change is not relevant to dark and light mode

#### Accessibility

- [ ] Automated WCAG 2.1 tests pass
- [ ] HTML validation passes
- [ ] Manual WCAG 2.1 tests completed
- [ ] I have tested in a screen reader
- [ ] I have tested in high-contrast mode
- [ ] Any animations removed for prefers-reduced-motion
- [x] Not required

#### Sustainability

- [ ] Images are optimised and lazy-loading used where appropriate
- [ ] SVGs have been optimised
- [ ] Performance and transfer of data considered
- [ ] If JavaScript is needed alternatives have been considered
- [x] Not required

#### Pattern library

- [ ] The pattern library component for this template displays correctly, and does not break parent templates
- [ ] The styleguide is updated if relevant
- [x} Changes are not relevant the pattern library
