### PR TITLE
Increase homepage sector cards from 3 to 4

### DIFF
--- a/tbx/core/blocks.py
+++ b/tbx/core/blocks.py
@@ -574,6 +574,7 @@ class DivisionSignpostCardBlock(blocks.StructBlock):
         CORAL = "theme-coral", "Coral"
         NEBULINE = "theme-nebuline", "Nebuline"
         LAGOON = "theme-lagoon", "Lagoon"
+        GREEN = "theme-green", "Green"
 
     card_colour = blocks.ChoiceBlock(
         choices=ColourTheme.choices, default=ColourTheme.CORAL, max_length=20
@@ -602,8 +603,8 @@ class DivisionSignpostBlock(blocks.StructBlock):
     )
     cards = blocks.ListBlock(
         DivisionSignpostCardBlock(),
-        max_num=3,
-        min_num=3,
+        max_num=4,
+        min_num=4,
     )
 
     class Meta:

--- a/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/division_signpost_block.html
+++ b/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/division_signpost_block.html
@@ -16,7 +16,7 @@
                     <h2 class="heading heading--two division-signpost__heading">{% firstof card.heading card.page.title %}</h2>
                     <div class="heading heading--four-b heading--light division-signpost__description">{{ card.description|richtext }}</div>
                 </div>
-                {% srcset_image card.image format-webp fill-{540x280,490x280} sizes="(max-width: 598px) 540px, (min-width: 599px) 490px" alt="" loading="lazy" %}
+                {% srcset_image card.image format-webp fill-{580x280,490x280} sizes="(max-width: 598px) 580px, (min-width: 599px) 490px" alt="" loading="lazy" %}
                 {# The title and icon need to be on the same line with no whitespace to prevent the arrow being orphaned on a new line #}
                 <a href="{% if card.page %}{% pageurl card.page %}{% endif %}"
                    class="button-link button-link--{{ card.card_colour }}"

--- a/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/division_signpost_block.html
+++ b/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/division_signpost_block.html
@@ -16,7 +16,7 @@
                     <h2 class="heading heading--two division-signpost__heading">{% firstof card.heading card.page.title %}</h2>
                     <div class="heading heading--four-b heading--light division-signpost__description">{{ card.description|richtext }}</div>
                 </div>
-                {% srcset_image card.image format-webp fill-{580x280,490x280} sizes="(max-width: 598px) 580px, (min-width: 599px) 490px" alt="" loading="lazy" %}
+                {% srcset_image card.image format-webp fill-{700x280,490x280} sizes="(max-width: 598px) 700px, (min-width: 599px) 490px" alt="" loading="lazy" %}
                 {# The title and icon need to be on the same line with no whitespace to prevent the arrow being orphaned on a new line #}
                 <a href="{% if card.page %}{% pageurl card.page %}{% endif %}"
                    class="button-link button-link--{{ card.card_colour }}"

--- a/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/division_signpost_block.yaml
+++ b/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/division_signpost_block.yaml
@@ -26,6 +26,6 @@ context:
 
 tags:
   srcset_image:
-    'card.image format-webp fill-{580x280,490x280} sizes="(max-width: 598px) 580px, (min-width: 599px) 490px" alt="" loading="lazy"':
+    'card.image format-webp fill-{700x280,490x280} sizes="(max-width: 598px) 700px, (min-width: 599px) 490px" alt="" loading="lazy"':
       raw: |
-        <img alt="" loading="lazy" height="280" sizes="(max-width: 598px) 580px, (min-width: 599px) 490px" src="https://picsum.photos/580/280.webp" srcset="https://picsum.photos/580/280.webp 580w, https://picsum.photos/490/280.webp 490w" width="580">
+        <img alt="" loading="lazy" height="280" sizes="(max-width: 598px) 700px, (min-width: 599px) 490px" src="https://picsum.photos/700/280.webp" srcset="https://picsum.photos/700/280.webp 700w, https://picsum.photos/490/280.webp 490w" width="700">

--- a/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/division_signpost_block.yaml
+++ b/tbx/project_styleguide/templates/patterns/molecules/streamfield/blocks/division_signpost_block.yaml
@@ -9,18 +9,23 @@ context:
         link_text: Find out more
         accessible_link_text: Find out more about our charity services
       - card_colour: 'theme-nebuline'
-        heading: Public
+        heading: Health
         description: Navigate complex challenges. Accelerate your mission and transform public services through digital
         link_text: Find out more
         accessible_link_text: Find out more about our public sector services
       - card_colour: 'theme-lagoon'
-        heading: Wagtail
+        heading: Public sector
         description: Empower your editors and developers to do their best work with Wagtail, the world's leading open-source Python CMS.
         link_text: Find out more
         accessible_link_text: Find out more about our Wagtail CMS services
+      - card_colour: 'theme-green'
+        heading: GLAM
+        description: Empower your editors and developers to do their best work with Wagtail, the world's leading open-source Python CMS.
+        link_text: Find out more
+        accessible_link_text: Find out more about our GLAM services
 
 tags:
   srcset_image:
-    'card.image format-webp fill-{540x280,490x280} sizes="(max-width: 598px) 540px, (min-width: 599px) 490px" alt="" loading="lazy"':
+    'card.image format-webp fill-{580x280,490x280} sizes="(max-width: 598px) 580px, (min-width: 599px) 490px" alt="" loading="lazy"':
       raw: |
-        <img alt="" loading="lazy" height="280" sizes="(max-width: 598px) 540px, (min-width: 599px) 490px" src="https://picsum.photos/540/280.webp" srcset="https://picsum.photos/540/280.webp 540w, https://picsum.photos/490/280.webp 490w" width="540">
+        <img alt="" loading="lazy" height="280" sizes="(max-width: 598px) 580px, (min-width: 599px) 490px" src="https://picsum.photos/580/280.webp" srcset="https://picsum.photos/580/280.webp 580w, https://picsum.photos/490/280.webp 490w" width="580">

--- a/tbx/static_src/sass/components/_button-link.scss
+++ b/tbx/static_src/sass/components/_button-link.scss
@@ -70,6 +70,14 @@
         }
     }
 
+    &--theme-green {
+        background-color: $color--green;
+
+        &:focus {
+            @include focus-style($outline-color: var(--color--green));
+        }
+    }
+
     &__tail {
         // Keep the arrow attached to the last word so it's not orphaned on a new line
         white-space: nowrap;
@@ -81,6 +89,8 @@
             $interaction-color: var(--color--button-link-interaction)
         );
         color: inherit;
-        margin-left: $spacer-mini;
+        margin-left: 10px;
+        // Nudge the vertical position of the arrow to align with the text
+        margin-top: 8px;
     }
 }

--- a/tbx/static_src/sass/components/_division-signpost.scss
+++ b/tbx/static_src/sass/components/_division-signpost.scss
@@ -26,8 +26,8 @@
             flex-basis: calc(50% - #{$spacer-mini-plus} * 0.5);
         }
 
-        @include media-query(large) {
-            flex-basis: calc(33.33% - ($spacer-mini-plus * 2 / 3));
+        @include media-query(xx-large) {
+            flex-basis: calc(25% - ($spacer-mini-plus * 0.75));
         }
 
         @include high-contrast-mode() {
@@ -52,6 +52,13 @@
             @include card-hover-style(
                 var(--color--lagoon),
                 var(--color--lagoon-dark)
+            );
+        }
+
+        &--theme-green {
+            @include card-hover-style(
+                var(--color--green),
+                var(--color--green-dark)
             );
         }
     }

--- a/tbx/static_src/sass/components/_grid.scss
+++ b/tbx/static_src/sass/components/_grid.scss
@@ -127,6 +127,15 @@
         }
     }
 
+    &__division-signpost {
+        // On desktop this container fits four cards in the same row
+        // We break out from the inner grid column so card contents aren't too squashed
+        @include media-query(xx-large) {
+            padding: 0 $spacer-medium;
+            grid-column: 1 / span 14;
+        }
+    }
+
     &__wide-image {
         margin-bottom: $spacer-medium;
         grid-column: 2 / span 5;

--- a/tbx/static_src/sass/config/_variables.scss
+++ b/tbx/static_src/sass/config/_variables.scss
@@ -85,6 +85,8 @@ $color--black: #000;
     --color--nebuline-dark: #{$color--nebuline-dark};
     --color--lagoon: #{$color--lagoon};
     --color--lagoon-dark: #{$color--lagoon-dark};
+    --color--green: #{$color--green};
+    --color--green-dark: #{$color--green-dark};
     --color--sky: #{$color--sky};
 }
 


### PR DESCRIPTION
There was no ticket for this work, context provided by Lily is as follows.

**Summary**
The homepage currently limits the sector cards component to a maximum of 3 items. As part of the new IA, we need to increase this to 4.

**Background**
We're removing the Wagtail CMS card and replacing the current three-card layout with four sectors:

- Charity
- Health
- Public Sector
- GLAM

At the moment, the card block in Wagtail has a hard limit of three items, preventing us from adding the fourth sector.

**Acceptance criteria**

- Increase the maximum number of cards from 3 to 4.
- Ensure the homepage layout supports four cards without breaking the design across desktop, tablet and mobile.

### Description of Changes Made

- Updated the DivisionSignpostBlock to support 4 items, breaking out of the grid container on desktop to give each card slightly more space to render.
- Made adjustments to color theme variables so that the green card renders correctly (including focus outline color for green card button)
- Tweaked the alignment of the arrow so that it aligns with the text in the card button.

### How to Test

Add four cards to the homepage, and verify they render well across viewports.

Check out the pattern library component locally: http://localhost:8000/pattern-library/render-pattern/patterns/molecules/streamfield/blocks/division_signpost_block.html

### Screenshots

<details>
  <summary>Expand to see more</summary>

Light mode, with focus state, on desktop.

<img width="1400" height="766" alt="image" src="https://github.com/user-attachments/assets/e9f116ca-72b2-4e9a-80de-750ed15c74c5" />

Dark mode, with focus state, on tablet - desktop. 

<img width="1273" height="834" alt="image" src="https://github.com/user-attachments/assets/bc1c4ccc-db0b-4c81-b50f-6a0c6e49307f" />

Safari - external monitor

<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/e4351e06-0a5c-4ad0-b121-27efbade0a87" />

</details>

### MR Checklist

- [ ] Add a description of your pull request and instructions for the reviewer to verify your work.
- [ ] If your pull request is for a specific ticket, link to it in the description.
- [ ] Stay on point and keep it small so the merge request can be easily reviewed.
- [ ] Tests and linting passes.

#### Unit tests

- [ ] Added
- [x] Not required

#### Documentation

- [ ] Updated build docs
- [ ] Updated editor guidelines (See https://intranet.torchbox.com/torchbox-com-project-docs for the private link, for Torchbox employees only)
- [ ] Updated field spec (See https://intranet.torchbox.com/torchbox-com-project-docs for the private link, for Torchbox employees only)
- [x] Not required

#### Browser testing

- [x] I have tested in the following browsers and environments (edit the list as required)
  - Latest version of Chrome on mac
  - Latest version of Firefox on mac
  - Latest version of Safari on mac
  - Safari on last two versions of iOS
  - Chrome on last two versions of Android
- [ ] Not required

#### Data protection

- [x] Not relevant
- [ ] This adds new sources of PII and documents it and modifies Birdbath processors accordingly

#### Light and dark mode

- [x] I have tested the changes in both light and dark mode
- [ ] The change is not relevant to dark and light mode

#### Accessibility

- [x] Automated WCAG 2.1 tests pass
- [x] HTML validation passes
- [x] Manual WCAG 2.1 tests completed
- [x] I have tested in a screen reader
- [x] I have tested in high-contrast mode
- [x] Any animations removed for prefers-reduced-motion
- [ ] Not required

#### Sustainability

- [x] Images are optimised and lazy-loading used where appropriate
- [ ] SVGs have been optimised
- [ ] Performance and transfer of data considered
- [ ] If JavaScript is needed alternatives have been considered
- [ ] Not required

#### Pattern library

- [ ] The pattern library component for this template displays correctly, and does not break parent templates
- [ ] The styleguide is updated if relevant
- [ ] Changes are not relevant the pattern library
